### PR TITLE
Add logic trigger to operationlog

### DIFF
--- a/operationlog/README.md
+++ b/operationlog/README.md
@@ -125,6 +125,40 @@ The code is replaced by the return value of the \<python code> for the logtext. 
         olog_level = info
 ```
 
+## Logics
+Configure a logic to be logged as follows:
+
+```
+[some_logic]
+    filename = script.py
+    olog = mylogname1
+    #olog_txt = The logic {logic.name} was triggered!
+    #olog_level = INFO
+```
+
+To enable logging for a given logic when it is triggered just
+add the `olog` attribute to the logic configuration. As default a simple
+logtext is logged: Logic {logic.name} triggered.
+
+Optionally you can overwrite the default logtext using the `olog_txt`
+attribute. In contrast to the item setting this supports different predefined
+keys as listed below:
+
+Key         | Description
+----------- | -----------
+`{plugin.*}`| the plugin instance (e.g. plugin.name for the name of the plugin)
+`{logic.*}` | the logic object (e.g. logic.name for the name)
+`{by}`      | name of the source of the logic trigger
+`{source}`  | identifies the source of change
+`{dest}`    | identifies the destination of change
+
+Furthermore user defined python expressions can be used in the logtext. Define as follows:
+
+`{eval=<python code>}`
+
+The code is replaced by the return value of the \<python code> for the logtext. Multiple `{eval=<python code>}` statements can be used.
+
+
 ## Functions
 
 ```


### PR DESCRIPTION
This patch will add support to configure logic using `operationlog` plugin to generate a log message each time the logic was triggered.

The feature is not new, it was previously implemented in the `memlog` plugin. Since the operationlog is a little bit more useable (can log to file, can cache the log, ...) I would also suggest to completely remove the `memlog` plugin later (not part of this PR).

To configure such a message for a logic trigger you can use the following settings in the `logic.conf`:
* olog = \<name\>
* olog_txt = "...."
* olog_level = \<level\>

PS: I added myself to the copyright notice since I think parts and ideas are from the original `memlog` plugin. Hope it's OK. If not, let me know.
