### PR TITLE
hue: fix group command 'on'

### DIFF
--- a/hue/__init__.py
+++ b/hue/__init__.py
@@ -466,10 +466,10 @@ class HUE():
                 # lampe ist an (status in sh). dann können alle befehle gesendet werden
                 if hueSendGroup == 'on':
                     # wenn der status in sh true ist, aber mit dem befehl on, dann muss die lampe auf der hue seite erst eingeschaltet werden
-                    if hueIndex + '.bri' in self._sendLampItems:
+                    if hueIndex + '.bri' in self._sendGroupItems:
                         # wenn eingeschaltet wird und ein bri item vorhanden ist, dann wird auch die hellgkeit
                         # mit gesetzt, weil die gruppe das im ausgeschalteten zustand vergisst.
-                        self._set_group_state(hueBridgeId, hueGroupId, {'on': True, 'bri': int(self._sendLampItems[(hueIndex + '.bri')]()) , 'transitiontime': hueTransitionTime})
+                        self._set_group_state(hueBridgeId, hueGroupId, {'on': True, 'bri': int(self._sendGroupItems[(hueIndex + '.bri')]()) , 'transitiontime': hueTransitionTime})
                     else:
                         # ansonst wird nur eingeschaltet
                         self._set_group_state(hueBridgeId, hueGroupId, {'on': True , 'transitiontime': hueTransitionTime})


### PR DESCRIPTION
Using the `on` command with groups results in an error message complaining about a missing lamp id. This change fixes this issue and swaps the item store variable of group command `on`. 

I'm aware that the target of this pull request is the `master` branch. This is due to changes which are missing on the `develop` branch.