### PR TITLE
Check if Bluetooth support is available in socket module

### DIFF
--- a/sma/__init__.py
+++ b/sma/__init__.py
@@ -205,6 +205,9 @@ class SMA(SmartPlugin):
         self._inv_bt_addr_le.reverse()
         self._plugin_active_item = None
 
+        if not hasattr(socket, 'AF_BLUETOOTH'):
+            raise Exception("Python socket module does not support Bluetooth - see README.md how to install")
+
     def _update_values(self):
         #logger.warning("sma: signal strength = {}%%".format(self._inv_get_bt_signal_strength()))
         self._cmd_lock.acquire()


### PR DESCRIPTION
This will check if the socket type AF_BLUETOOTH is available in the
socket module to avoid exceptions or error user will not be able
to handle. If Bluetooth support is not available hint the user to
install it and look up instructions in the readme.

See also https://github.com/smarthomeNG/smarthome/issues/229