### PR TITLE
visu_smartvisu: fix category menu on mobile devices

### DIFF
--- a/visu_smartvisu/tplNG/category.html
+++ b/visu_smartvisu/tplNG/category.html
@@ -8,33 +8,8 @@
 */
 
 
-{% extends "base.html" %}
-
-{% block sidebar %}
-	{% include 'category_nav.html' %}
-{% endblock %}
+{% extends "index.html" %}
 
 {% block content %}
-
-	Category Content
-
-	<h1><img class="icon" src='{{ icon0 }}time_manual_mode.svg' />Konfiurationen</h1>
-	<a href="index.php?page=wohnung.config">Konfiguration</a>&nbsp;
-	<a href="index.php?page=beschattung">Beschattung</a>&nbsp;
-	<a href="index.php?page=beleuchtung">Beleuchtungsautomatik</a>&nbsp;
-	<a href="index.php?page=wohnung.verteilung">Verteilung</a>&nbsp;
-	<a href="index.php?page=mlgw">B&O Masterlink Gateway</a>&nbsp;
-	<a href="index.php?page=beoremote">Lintronic - Beo4 Remote</a>&nbsp;
-	<a href="index.php?page=sonos_bo">Sonos Musiksystgem</a>&nbsp;
-	<br>
-
-	<h1><img class="icon" src='{{ icon0 }}time_manual_mode.svg' />Kategorien</h1>
-	<a href="index.php?page=sun_moon">Sonne & Mond</a>&nbsp;
-	<a href="index.php?page=wetter">Wetter (Wunderground)</a>&nbsp;
-	<a href="index.php?page=wohnung.stati">Wohnungs-Helligkeiten</a>&nbsp;
-	<a href="index.php?page=category_phone">Telefonliste</a>&nbsp;
-	<a href="index.php?page=category_calendar">Terminkalender</a>&nbsp;
-
+	{% include 'category_nav.html' %}
 {% endblock %}
-
-

--- a/visu_smartvisu/tplNG/category_page.html
+++ b/visu_smartvisu/tplNG/category_page.html
@@ -10,6 +10,10 @@
 
 {% extends "category.html" %}
 
+{% block sidebar %}
+	{% include 'category_nav.html' %}
+{% endblock %}
+
 {% block content %}
 
 	<h1><img class="icon" src='{{ icon0 }}{{ visu_img }}' />{{ visu_name }}</h1>


### PR DESCRIPTION
By default, category site contained `category_nav` in `sidebar block` and bunch of broken links in German in `content block`. Since there's no sidebar in smaller resolutions (like mobile phones), there's no other access to category item than manually editing address. This commit changes category behavior to act similar to rooms:
 -  `category_nav` in `content block` when selected category from menu; clock & weather in `sidebar block`
-  `category_nav` in `sidebar block` when selected specific category from  `category_nav`