### PR TITLE
KNX typo fix

### DIFF
--- a/knx/__init__.py
+++ b/knx/__init__.py
@@ -574,13 +574,13 @@ class KNX(lib.connection.Client,SmartPlugin):
     - adresses that do not react upon requests
     - adresses that can't satisfy cache requests
     """
-    def enable_stats(sef):
+    def enable_stats(self):
         """
         Enables the tracking of KNX telegrams during runtime of SmartHomeNG
         """
         self.enable_stats = True
 
-    def disable_stats(sef):
+    def disable_stats(self):
         """
         Disables the tracking of KNX telegrams during runtime of SmartHomeNG
         It might be a good idea to clear your stats afterwards with clear_stats()


### PR DESCRIPTION
This PR fixes a minor typing error in two methods from the KNX plugin. Replaced #73 which was requested to the wrong branch.