### PR TITLE
Enochean Bugfix

### DIFF
--- a/enocean/README.md
+++ b/enocean/README.md
@@ -71,12 +71,14 @@ An Enocean item must specify at minimum an ``enocean_rx_id`` (Enocean Identifica
         enocean_rx_id = 0180924D
         enocean_rx_eep = A5_02_05
         enocean_rx_key = TMP
+    
     [[Door]]
         enocean_rx_id = 01234567
         enocean_rx_eep = D5_00_01
         [[[status]]]
             type = bool
             enocean_rx_key = STATUS
+    
     [[FT55switch]]
         enocean_rx_id = 012345AA
         enocean_rx_eep = F6_02_03
@@ -86,6 +88,17 @@ An Enocean item must specify at minimum an ``enocean_rx_id`` (Enocean Identifica
             [[[down]]]
                 type = bool
                 enocean_rx_key = BI
+    
+    [[Brightness_Sensor]]
+        name = brightness_sensor_east
+        remark = Eltako FAH60
+        type = num
+        enocean_rx_id = 01A51DE6
+        enocean_rx_eep = A5_06_01
+        enocean_rx_key = BRI
+        visu_acl = rw
+        sqlite = yes
+    
     [[dimmer1]]
         enocean_rx_id = 00112233
         enocean_rx_eep = A5_11_04
@@ -100,18 +113,21 @@ An Enocean item must specify at minimum an ``enocean_rx_id`` (Enocean Identifica
                 enocean_tx_eep = A5_38_08_03
                 enocean_tx_id_offset = 1
                 ref_level = 80
+    
     [[handle]]
         enocean_rx_id = 01234567
         enocean_rx_eep = F6_10_00
         [[[status]]]
             type = num
             enocean_rx_key = STATUS
+    
     [[actor1]]
         enocean_rx_id = FFAABBCC
         enocean_rx_eep = A5_12_01
         [[[power]]]
             type = num
             enocean_rx_key = VALUE
+    
     [[actor1B]]
         enocean_rx_id = FFAABBCD
         enocean_rx_eep = F6_02_03
@@ -120,6 +136,7 @@ An Enocean item must specify at minimum an ``enocean_rx_id`` (Enocean Identifica
             enocean_rx_key = B
             enocean_tx_eep = A5_38_08_01
             enocean_tx_id_offset = 2
+    
     [[actorD2]]
         enocean_rx_id = FFDB7381
         enocean_rx_eep = D2_01_07
@@ -129,6 +146,7 @@ An Enocean item must specify at minimum an ``enocean_rx_id`` (Enocean Identifica
             enocean_tx_eep = D2_01_07
             enocean_pulsewidth = 0.1  // optional; turn off after 0.1 sed
             enocean_tx_id_offset = 1  
+    
     [[awning]]
         enocean_rx_id = 0500E508
         enocean_rx_eep = F6_02_03
@@ -143,6 +161,7 @@ An Enocean item must specify at minimum an ``enocean_rx_id`` (Enocean Identifica
             cache = on
             type = bool
             visu = yes
+    
     [[rocker]]
         enocean_rx_id = 0029894A
         enocean_rx_eep = F6_02_01
@@ -168,6 +187,7 @@ An Enocean item must specify at minimum an ``enocean_rx_id`` (Enocean Identifica
             enocean_rocker_sequence = **released within 0.4, pressed within 0.4**
             knx_dpt = 1
             knx_send = 3/0/62
+    
     [[brightness_sensor]]
         enocean_rx_id = 01234567
         enocean_rx_eep = A5_08_01
@@ -177,6 +197,7 @@ An Enocean item must specify at minimum an ``enocean_rx_id`` (Enocean Identifica
         [[[movement]]]
             type = bool
             enocean_rx_key = MOV
+    
     [[temperature_sensor]]
         enocean_rx_id = 01234567
         enocean_rx_eep = A5_04_02
@@ -189,6 +210,7 @@ An Enocean item must specify at minimum an ``enocean_rx_id`` (Enocean Identifica
         [[[power_status]]]
             type = num
             enocean_rx_key = ENG
+    
     [[sunblind]]
         enocean_rx_id = 0500xxxx
         enocean_rx_eep = F6_02_03
@@ -232,7 +254,7 @@ Enocean_Item:
                 enocean_rx_key: BI
     
     Brightness_Sensor:
-                name: HelligkeitssensorOst
+                name: brightness_sensor_east
                 remark: Eltako FAH60
                 type: num
                 enocean_rx_id: 01A51DE6
@@ -390,7 +412,7 @@ The following status EEPs are supported:
 * A5_08_01		Brightness and movement sensor
 * A5_11_04		Dimmer status feedback
 * A5_12_01		Power Measurement
-* D2_01_07              Simple electronic switch
+* D2_01_07		Simple electronic switch
 * D5_00_01		Door/Window Contact, e.g. Eltako FTK, FTKB
 * F6_02_01		2-Button-Rocker
 * F6_02_02		2-Button-Rocker
@@ -407,7 +429,7 @@ A complete list of available EEPs is documented at [EnOcean Alliance](http://www
 * A5_38_08_02		Dimmer command with fix on off command (on: 100, off:0)
 * A5_38_08_03		Dimmer command with specified dim level (0-100)
 * A5_3F_7F		Universal actuator command, e.g. blind control
-* D2_01_07              Simple electronic switch
+* D2_01_07		Simple electronic switch
 ```
 
 The optional ref_level parameter defines default dim value when dimmer is switched on via on command.
@@ -425,7 +447,7 @@ cd /usr/local/smarthome/bin
 sudo systemctl stop smarthome
 sudo ./smarthome.py -i
 ```
-	
+
 Then use one of the following learn-in commands, depending on your enocean device:
 
 ```python

--- a/enocean/__init__.py
+++ b/enocean/__init__.py
@@ -777,40 +777,35 @@ class EnOcean(SmartPlugin):
             # Prepare Data for Eltako switch FSR61
             payload = [0xE0, 0x40, 0x0D, 0x80]
             self.logger.info('enocean: sending learn telegram for switch command with [Device], [ID-Offset], [RORG], [payload] / [{}], [{:#04x}], [{:#04x}], [{}]'.format(device, id_offset, rorg, ', '.join('{:#04x}'.format(x) for x in payload)))
-            return None
         # device range 20 - 29 --> Learn protocol for dim actuators
         elif (device == 20):
             # Only for Eltako FSUD-230V
             payload = [0x02, 0x00, 0x00, 0x00]
             self.logger.info('enocean: sending learn telegram for dim command with [Device], [ID-Offset], [RORG], [payload] / [{}], [{:#04x}], [{:#04x}], [{}]'.format(device, id_offset, rorg, ', '.join('{:#04x}'.format(x) for x in payload)))
-            return None
         elif (device == 21):
             # For Eltako FHK61SSR dim device (EEP A5-38-08)
             payload = [0xE0, 0x40, 0x0D, 0x80]
             self.logger.info('enocean: sending learn telegram for dim command with [Device], [ID-Offset], [RORG], [payload] / [{}], [{:#04x}], [{:#04x}], [{}]'.format(device, id_offset, rorg, ', '.join('{:#04x}'.format(x) for x in payload)))
-            return None
         elif (device == 22):
             # For Eltako FRGBW71L RGB dim devices (EEP 07-3F-7F)
             payload = [0xFF, 0xF8, 0x0D, 0x87]
             self.logger.info('enocean: sending learn telegram for rgbw dim command with [Device], [ID-Offset], [RORG], [payload] / [{}], [{:#04x}], [{:#04x}], [{}]'.format(device, id_offset, rorg, ', '.join('{:#04x}'.format(x) for x in payload)))
-            return None
         # device range 30 - 39 --> Learn protocol for radiator valves
         elif (device == 30):
             # Radiator Valve
             payload = [0x00, 0x00, 0x00, 0x00]
             self.logger.info('enocean: sending learn telegram for radiator valve with [Device], [ID-Offset], [RORG], [payload] / [{}], [{:#04x}], [{:#04x}], [{}]'.format(device, id_offset, rorg, ', '.join('{:#04x}'.format(x) for x in payload)))
-            return None
         # device range 40 - 49 --> Learn protocol for other actuators
         elif (device == 40):
             # Eltako shutter actor FSB14, FSB61, FSB71
              payload = [0xFF, 0xF8, 0x0D, 0x80]
              self.logger.info('enocean: sending learn telegram for actuator with [Device], [ID-Offset], [RORG], [payload] / [{}], [{:#04x}], [{:#04x}], [{}]'.format(device, id_offset, rorg, ', '.join('{:#04x}'.format(x) for x in payload)))
-             return None
         else:
             self.logger.error('enocean: sending learn telegram with invalid device! Device {} actually not defined!'.format(device))
             return None
         # Send radio package
         self._send_radio_packet(id_offset, rorg, payload)
+        return None
 
 
     def start_UTE_learnmode(self, id_offset=0):

--- a/enocean/eep_parser.py
+++ b/enocean/eep_parser.py
@@ -105,9 +105,12 @@ class EEP_Parser():
     def _parse_eep_A5_04_02(self, payload, status):
         # Energy (optional), humidity and temperature, for example eltako FBH65TFB
         result = {}
-        result['ENG'] = 0.47 + (payload[0] * 1.5 / 66)       # voltage of energy buffer in Volts
-        result['HUM'] = (payload[1] / 250.0 * 100)           # relative humidity in percent
-        result['TMP'] = -20.0 + (payload[2] / 250.0 * 80.0)  # temperature in degree Celsius from -20.0 degC - 60degC
+        # voltage of energy buffer in Volts
+        result['ENG'] = 0.47 + (payload[0] * 1.5 / 66)
+        # relative humidity in percent
+        result['HUM'] = (payload[1] / 250.0 * 100)
+        # temperature in degree Celsius from -20.0 degC - 60degC
+        result['TMP'] = -20.0 + (payload[2] / 250.0 * 80.0)
         return result
         
     def _parse_eep_A5_06_01(self, payload, status):
@@ -124,8 +127,9 @@ class EEP_Parser():
         else:
             # No Data Message
             result['BRI'] = (-1)
-        self.logger.info('enocean: brightness: {0}'.format(result['BRI']))
-        # self.logger.debug("enocean: movement data byte0: {0}".format(payload[3]))
+        # only trigger the logger info when 'BRI' > 0
+        if (result['BRI'] > 0):
+            self.logger.info('enocean: brightness: {0}'.format(result['BRI']))
         return result
 
     def _parse_eep_A5_08_01(self, payload, status):
@@ -151,9 +155,11 @@ class EEP_Parser():
         #    self.logger.error("enocean: error in processing A5_11_04: static byte missmatch")
         #    return results
         results['D'] = payload[1]
-        if (payload[3] == 0x08):               # Dimmer is off
+        if (payload[3] == 0x08):
+            # Dimmer is off
             results['STAT'] = 0
-        elif (payload[3] == 0x09):             # Dimmer is on
+        elif (payload[3] == 0x09):
+            # Dimmer is on
             results['STAT'] = 1
         return results
 
@@ -171,9 +177,12 @@ class EEP_Parser():
         self.logger.debug("enocean: processing A5_20_04")
         results = {}
         status_byte = payload[3]
-        TS = ((status_byte & 1 << 6) == 1 << 6) #1: temperature setpoint, 0: feed temperature
-        FL = ((status_byte & 1 << 7) == 1 << 7) #1: failure, 0: normal
-        BLS= ((status_byte& 1 << 5) == 1 << 5)  #1: locked, 0: unlocked
+        #1: temperature setpoint, 0: feed temperature
+        TS = ((status_byte & 1 << 6) == 1 << 6)
+        #1: failure, 0: normal
+        FL = ((status_byte & 1 << 7) == 1 << 7)
+        #1: locked, 0: unlocked
+        BLS= ((status_byte& 1 << 5) == 1 << 5)
         results['BLS'] = BLS
         # current valve position 0-100%
         results['CP'] = payload[0]
@@ -209,15 +218,19 @@ class EEP_Parser():
         results['AD_2'] = payload[0] * 1.8 / pow(2, 8)
         return results
 
+#####################################################
+### --- Definitions for RORG = D2  / ORG = D2 --- ###
+#####################################################
     def _parse_eep_D2_01_07(self, payload, status):
-        #ORG = 0xD2
-        #logger.debug("enocean: processing D2_01_07: VLD Switch")
+        # self.logger.debug("enocean: processing D2_01_07: VLD Switch")
         results = {}
-        #self.logger.info('enocean: D2 Switch Feedback  0:{} 1:{} 2:{}').format(payload[0],payload[1],payload[2])
-        if (payload[2] == 0x80):               # Switch is off
+        # self.logger.info('enocean: D2 Switch Feedback  0:{} 1:{} 2:{}').format(payload[0],payload[1],payload[2])
+        if (payload[2] == 0x80):
+            # Switch is off
             results['STAT'] = 0
             self.logger.debug('enocean: D2 Switch off')
-        elif (payload[2] == 0xe4):             # Switch is on
+        elif (payload[2] == 0xe4):
+            # Switch is on
             results['STAT'] = 1
             self.logger.debug('enocean: D2 Switch on')
         return results

--- a/enocean/eep_parser.py
+++ b/enocean/eep_parser.py
@@ -208,6 +208,7 @@ class EEP_Parser():
         results['AD_1'] = (payload[1] >> 2) * 1.8 / pow(2, 6)
         results['AD_2'] = payload[0] * 1.8 / pow(2, 8)
         return results
+
     def _parse_eep_D2_01_07(self, payload, status):
         #ORG = 0xD2
         #logger.debug("enocean: processing D2_01_07: VLD Switch")


### PR DESCRIPTION
# eep_parser
- add empty line between two methods
- only send logger.info for Eltako FAH60 when Brigthness > 0
- add header for RORG = D2
- small improvements of comments

# Readme.md
- Add brightness sensor example for item.conf in Readme.md


# init.py - Bugfix
- remove 6 x return None. Was forgotten to remove