### PR TITLE
HUE-plugin: fix readme (lists are always required) and authorize-func

### DIFF
--- a/hue/README.md
+++ b/hue/README.md
@@ -60,8 +60,10 @@ Minimal configuration for single bridge an default settings
 HUE:
     class_name: HUE
     class_path: plugins.hue
-    hue_user: 38f625a739562a8bd261ab9c7f5e62c8
-    hue_ip: 192.168.2.2
+    hue_user:
+      - 38f625a739562a8bd261ab9c7f5e62c8
+    hue_ip:
+      - 192.168.2.2
 ```
 
 #### hue_user

--- a/hue/__init__.py
+++ b/hue/__init__.py
@@ -780,7 +780,7 @@ class HUE(SmartPlugin):
 
     def authorizeuser(self, hueBridgeId='0'):
         data = json.dumps(
-            {"devicetype": "smarthome", "username": self._hue_user[int(hueBridgeId)]})
+            {"devicetype": "smarthome#" + self._hue_user[int(hueBridgeId)]})
         con = http.client.HTTPConnection(self._hue_ip[int(hueBridgeId)])
         con.request("POST", "/api", data)
         resp = con.getresponse()
@@ -788,7 +788,7 @@ class HUE(SmartPlugin):
         if resp.status != 200:
             self.logger.error('authorize: Authenticate request failed')
             return "Authenticate request failed"
-        resp = resp.read()
+        resp = resp.read().decode('utf-8')
         self.logger.debug(resp)
         resp = json.loads(resp)
         self.logger.debug(resp)


### PR DESCRIPTION
Fix two severe flaws which are no good entry for novice users without debug-experience:
- Readme mentions wrong configuration for easy setups - lists are always required, checks are notr obvious or not working
- authorize-func crashes because of unproper conversion from bytes to string, after it fails at it does not use format mandated by https://www.developers.meethue.com/documentation/getting-started


