### PR TITLE
AVDevice: fixed problem with multi-command

### DIFF
--- a/avdevice/__init__.py
+++ b/avdevice/__init__.py
@@ -96,9 +96,9 @@ class AVDevice(SmartPlugin):
 		self._is_connected = []
 		self._parsinginput = []
 		self._dependencies = {'Slave_function': {'zone0': {}, 'zone1': {}, 'zone2': {}, 'zone3': {}, 'zone4': {}}, \
-					   		'Slave_item': {'zone0': {}, 'zone1': {}, 'zone2': {}, 'zone3': {}, 'zone4': {}}, \
-					   		'Master_function': {'zone0': {}, 'zone1': {}, 'zone2': {}, 'zone3': {}, 'zone4': {}}, \
-					   		'Master_item': {'zone0': {}, 'zone1': {}, 'zone2': {}, 'zone3': {}, 'zone4': {}}}
+							'Slave_item': {'zone0': {}, 'zone1': {}, 'zone2': {}, 'zone3': {}, 'zone4': {}}, \
+							'Master_function': {'zone0': {}, 'zone1': {}, 'zone2': {}, 'zone3': {}, 'zone4': {}}, \
+							'Master_item': {'zone0': {}, 'zone1': {}, 'zone2': {}, 'zone3': {}, 'zone4': {}}}
 
 		try:
 			self._model = self.get_parameter_value('model')
@@ -2224,7 +2224,12 @@ class AVDevice(SmartPlugin):
 									for sendcommand in self._send_commands:
 										self.logger.log(VERBOSE1, "Updating Item {}: Testing send command: {}".format(self._name, sendcommand))
 										if commandinfo[3] in sendcommand:
-											valuetype = sendcommand.split(';')[0].split('|').split(',')
+											splitfind = sendcommand.split(',', 2)[2]
+											before = sendcommand.split(',', 2)[0:2]
+											if splitfind.find('|') >= 0:
+												after = [splitfind.split('|')[1]]
+												sendcommand = ','.join(before+after)
+											valuetype = sendcommand.split(';')[0].split(',')
 											if valuetype[len(valuetype)-1].isdigit():
 												valuetype.pop(len(valuetype)-1)
 											try:

--- a/avdevice/__init__.py
+++ b/avdevice/__init__.py
@@ -1292,9 +1292,10 @@ class AVDevice(SmartPlugin):
 						expectedresponse = []
 						try:
 							for resp in self._send_commands:
-								splitresponse=resp.split('|')
-								if isinstance(splitresponse, list) and len(splitresponse) > 1:
-									splitresponse[0:len(splitresponse)-1] = ['|'.join(splitresponse[0:len(splitresponse)-1])]
+								if resp.split(',', 2)[2].find('|') >= 0:
+									splitresponse=resp.split('|')
+								else:
+									splitresponse = [resp]
 								splitresponse[0] = splitresponse[0].split(',')[2]
 								for i in range(0, len(splitresponse)):
 									splitresponse[i] = splitresponse[i].split(',')[0]
@@ -1362,7 +1363,10 @@ class AVDevice(SmartPlugin):
 											expectedindices = _duplicateindex(expectedresponse, expected)
 											for expectedindex in expectedindices:
 												if self._send_commands[expectedindex] not in deletecommands:
-													expectedtype = self._send_commands[expectedindex].split(';')[0].split('|')[0].split(',')
+													if self._send_commands[expectedindex].split(',', 2)[2].find('|') >= 0:
+														expectedtype = self._send_commands[expectedindex].split(';')[0].split('|')[0].split(',')
+													else:
+														expectedtype = self._send_commands[expectedindex].split(';')[0].split(',')
 													try:
 														int(expectedtype[-1])
 														length = len(expectedtype)-1
@@ -1564,12 +1568,14 @@ class AVDevice(SmartPlugin):
 											testcommand = data.split('?')[0]
 											commandstarts = []
 											for entry in self._response_commands:
-												commandstarts.append(entry.split('?')[0])
+												if entry.split('?')[0] in testcommand:
+													commandstarts.append(entry.split('?')[0])
+
 											self.logger.log(VERBOSE1, "Parsing Input {}: Commandstarts {}. testcommand {}".format(self._name, commandstarts, testcommand))
-											if commandstarts.count(testcommand) > 1:
-												updated = 0
-											else:
+											if len(commandstarts) >= 1:
 												updated = 1
+											else:
+												updated = 0
 										except Exception as err:
 											self.logger.error("Parsing Input {}: Problem with new tests {}".format(self._name, err))
 										self._wait(0.15)

--- a/avdevice/plugin.yaml
+++ b/avdevice/plugin.yaml
@@ -185,38 +185,38 @@ item_attributes:
     avdevice_zone0_depend:
         type: list(str)
         description:
-            de: 'bla'
-            en: 'bla'
+            de: 'Hier wird der Funktionsname eingefügt, von dem ein Item abhängig sein soll. Der Bass des Verstärkers lässt sich beispielsweise nur ändern, wenn Tone aktiviert ist. "tone = True" führt dazu, dass das Item nur geändert wird, wenn die Bedingung erfüllt ist. Mehrere Bedingungen werden als "oder" interpretiert.'
+            en: 'Insert a function name your item should be depending on. For exmaple changing the Bass value of your amp is only useful/possible, if tone is activated. "tone = True" makes sure, that the item only gets updated if the dependency is fullfilled. Multiple entries are interepreted as "or".'
 
     avdevice_zone1_depend:
         type: list(str)
         description:
-            de: 'bla'
-            en: 'bla'
+            de: 'Hier wird der Funktionsname eingefügt, von dem ein Item abhängig sein soll. Der Bass des Verstärkers lässt sich beispielsweise nur ändern, wenn Tone aktiviert ist. "tone = True" führt dazu, dass das Item nur geändert wird, wenn die Bedingung erfüllt ist. Mehrere Bedingungen werden als "oder" interpretiert.'
+            en: 'Insert a function name your item should be depending on. For exmaple changing the Bass value of your amp is only useful/possible, if tone is activated. "tone = True" makes sure, that the item only gets updated if the dependency is fullfilled. Multiple entries are interepreted as "or".'
 
     avdevice_zone2_depend:
         type: list(str)
         description:
-            de: 'bla'
-            en: 'bla'
+            de: 'Hier wird der Funktionsname eingefügt, von dem ein Item abhängig sein soll. Der Bass des Verstärkers lässt sich beispielsweise nur ändern, wenn Tone aktiviert ist. "tone = True" führt dazu, dass das Item nur geändert wird, wenn die Bedingung erfüllt ist. Mehrere Bedingungen werden als "oder" interpretiert.'
+            en: 'Insert a function name your item should be depending on. For exmaple changing the Bass value of your amp is only useful/possible, if tone is activated. "tone = True" makes sure, that the item only gets updated if the dependency is fullfilled. Multiple entries are interepreted as "or".'
 
     avdevice_zone3_depend:
         type: list(str)
         description:
-            de: 'bla'
-            en: 'bla'
+            de: 'Hier wird der Funktionsname eingefügt, von dem ein Item abhängig sein soll. Der Bass des Verstärkers lässt sich beispielsweise nur ändern, wenn Tone aktiviert ist. "tone = True" führt dazu, dass das Item nur geändert wird, wenn die Bedingung erfüllt ist. Mehrere Bedingungen werden als "oder" interpretiert.'
+            en: 'Insert a function name your item should be depending on. For exmaple changing the Bass value of your amp is only useful/possible, if tone is activated. "tone = True" makes sure, that the item only gets updated if the dependency is fullfilled. Multiple entries are interepreted as "or".'
 
     avdevice_zone4_depend:
         type: list(str)
         description:
-            de: 'bla'
-            en: 'bla'
+            de: 'Hier wird der Funktionsname eingefügt, von dem ein Item abhängig sein soll. Der Bass des Verstärkers lässt sich beispielsweise nur ändern, wenn Tone aktiviert ist. "tone = True" führt dazu, dass das Item nur geändert wird, wenn die Bedingung erfüllt ist. Mehrere Bedingungen werden als "oder" interpretiert.'
+            en: 'Insert a function name your item should be depending on. For exmaple changing the Bass value of your amp is only useful/possible, if tone is activated. "tone = True" makes sure, that the item only gets updated if the dependency is fullfilled. Multiple entries are interepreted as "or".'
 
     avdevice_depend:
         type: list(str)
         description:
-            de: 'bla'
-            en: 'bla'
+            de: 'Hier wird der Funktionsname eingefügt, von dem ein Item abhängig sein soll. Der Bass des Verstärkers lässt sich beispielsweise nur ändern, wenn Tone aktiviert ist. "tone = True" führt dazu, dass das Item nur geändert wird, wenn die Bedingung erfüllt ist. Mehrere Bedingungen werden als "oder" interpretiert.'
+            en: 'Insert a function name your item should be depending on. For exmaple changing the Bass value of your amp is only useful/possible, if tone is activated. "tone = True" makes sure, that the item only gets updated if the dependency is fullfilled. Multiple entries are interepreted as "or".'
 
     avdevice_zone0:
         type: str


### PR DESCRIPTION
If command like 'PO|PO' is sent the command isn't removed even when response is as expected. Fixed this bug.