### PR TITLE
Re-Add slack plugin

### DIFF
--- a/slack/README.md
+++ b/slack/README.md
@@ -1,0 +1,63 @@
+# smarthome-slack
+Plugin to send push notifications to Slack 
+
+## Installation
+<pre>
+cd smarthome.py directory
+cd plugins
+git clone https://github.com/rthill/slack.git
+</pre>
+
+## Configuration
+### etc/plugin.yaml single instance example
+<pre>
+SlackInstance:
+    plugin_name: slack
+    token: abc/def/ghi # Token for posting to workspace '<your_team>'
+</pre>
+
+### etc/plugin.yaml multi instance example
+If you want to post to more than one Slack workspaces or if you want to use more than one incoming webhook / authentication token, configure this plugin with multiple instances.
+<pre>
+SlackInstance_1:
+    plugin_name: slack
+    instance: WorkspaceYourTeam
+    token: abc/def/ghi # Token for posting to workspace '<your_team>'
+	
+SlackInstance_2:
+    plugin_name: slack
+    instance: WorkspaceAnotherTeam
+    token: jkl/mno/pqr # Token for posting to another workspace '<another_team>'
+</pre>
+
+## Usage
+To enable posting to Slack you need to create an "incoming webhook" there, which gives you an authorization token.
+Open the following URL for your team workspace.
+https://<your_team>.slack.com/apps/new/A0F7XDUAZ-incoming-webhooks
+Create a new webhook at which you need to select one channel of your workspace.
+The created URL contains an API token which authorizes posting to every channel in this workspace.
+Afterwards you need to setup your etc/plugin.yaml as described above and insert the webhook token.
+
+To send a notification use the following syntax in your logics with the first parameter being the desired channel:
+<pre>
+# Default informational notification to channel #general
+sh.SlackInstance.notify('#general', 'Ding Dong: Front door')
+# Or use the following to set the default notification type to normal
+sh.SlackInstance.notify('#otherChannel', 'Ding Dong: Front door', 'normal')
+# Other notification types use warning, danger or good.
+sh.SlackInstance.notify('#differentChannel', 'Alarm: Garage door open', 'danger')
+</pre>
+
+To learn more on message formatting (e.g. bold, underline, URLs, Emojis, multiline) visit the following link:
+https://api.slack.com/docs/message-formatting
+
+
+For most users a single instance would be sufficient.
+If you want to send notifications to more than one Slack workspace or if you want to use more than one incoming webhook / authentication token, you need to generate a webhook / token in every Slack workspace.
+For each of them you'll need to configure a instace of this plugn in etc/plugin.yaml with different instance names as shown in multi instance example configuration above.
+Sending notifications in multi instance example:
+<pre>
+# Sending a notification to two workspaces
+sh.SlackInstance_1.notify('#general', 'Hello first workspace!')
+sh.SlackInstance_2.notify('#general', 'Hello second workspace!')
+</pre>

--- a/slack/README.md
+++ b/slack/README.md
@@ -10,13 +10,13 @@ SlackInstance:
 ```
 
 ### etc/plugin.yaml multi instance example
-If you want to post to more than one Slack workspaces or if you want to use more than one incoming webhook / authentication token, configure this plugin with multiple instances.
+If you want to post to more than one Slack workspace or if you want to use more than one incoming webhook / authentication token, configure this plugin with multiple instances.
 ```yaml
 SlackInstance_1:
     plugin_name: slack
     instance: WorkspaceYourTeam
     token: abc/def/ghi # Token for posting to workspace '<your_team>'
-	
+
 SlackInstance_2:
     plugin_name: slack
     instance: WorkspaceAnotherTeam
@@ -46,7 +46,7 @@ https://api.slack.com/docs/message-formatting
 
 
 For most users a single instance would be sufficient.
-If you want to send notifications to more than one Slack workspace or if you want to use more than one incoming webhook / authentication token, you need to generate a webhook / token in every Slack workspace.
+If you want to go beyond that and want to send notifications to more than one Slack workspace or if you want to use more than one incoming webhook / authentication token, you need to generate a webhook / token in every Slack workspace.
 For each of them you'll need to configure a instace of this plugn in etc/plugin.yaml with different instance names as shown in multi instance example configuration above.
 Sending notifications in multi instance example:
 ```python

--- a/slack/README.md
+++ b/slack/README.md
@@ -1,24 +1,17 @@
 # smarthome-slack
 Plugin to send push notifications to Slack 
 
-## Installation
-<pre>
-cd smarthome.py directory
-cd plugins
-git clone https://github.com/rthill/slack.git
-</pre>
-
 ## Configuration
 ### etc/plugin.yaml single instance example
-<pre>
+```yaml
 SlackInstance:
     plugin_name: slack
     token: abc/def/ghi # Token for posting to workspace '<your_team>'
-</pre>
+```
 
 ### etc/plugin.yaml multi instance example
 If you want to post to more than one Slack workspaces or if you want to use more than one incoming webhook / authentication token, configure this plugin with multiple instances.
-<pre>
+```yaml
 SlackInstance_1:
     plugin_name: slack
     instance: WorkspaceYourTeam
@@ -28,7 +21,7 @@ SlackInstance_2:
     plugin_name: slack
     instance: WorkspaceAnotherTeam
     token: jkl/mno/pqr # Token for posting to another workspace '<another_team>'
-</pre>
+```
 
 ## Usage
 To enable posting to Slack you need to create an "incoming webhook" there, which gives you an authorization token.
@@ -39,14 +32,14 @@ The created URL contains an API token which authorizes posting to every channel 
 Afterwards you need to setup your etc/plugin.yaml as described above and insert the webhook token.
 
 To send a notification use the following syntax in your logics with the first parameter being the desired channel:
-<pre>
+```python
 # Default informational notification to channel #general
 sh.SlackInstance.notify('#general', 'Ding Dong: Front door')
 # Or use the following to set the default notification type to normal
 sh.SlackInstance.notify('#otherChannel', 'Ding Dong: Front door', 'normal')
 # Other notification types use warning, danger or good.
 sh.SlackInstance.notify('#differentChannel', 'Alarm: Garage door open', 'danger')
-</pre>
+```
 
 To learn more on message formatting (e.g. bold, underline, URLs, Emojis, multiline) visit the following link:
 https://api.slack.com/docs/message-formatting
@@ -56,8 +49,8 @@ For most users a single instance would be sufficient.
 If you want to send notifications to more than one Slack workspace or if you want to use more than one incoming webhook / authentication token, you need to generate a webhook / token in every Slack workspace.
 For each of them you'll need to configure a instace of this plugn in etc/plugin.yaml with different instance names as shown in multi instance example configuration above.
 Sending notifications in multi instance example:
-<pre>
+```python
 # Sending a notification to two workspaces
 sh.SlackInstance_1.notify('#general', 'Hello first workspace!')
 sh.SlackInstance_2.notify('#general', 'Hello second workspace!')
-</pre>
+```

--- a/slack/__init__.py
+++ b/slack/__init__.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+# vim: set encoding=utf-8 tabstop=4 softtabstop=4 shiftwidth=4 expandtab
+#########################################################################
+#  Copyright 2016-2018 Raoul Thill                  raoul.thill@gmail.com
+#########################################################################
+#  This file is part of SmartHomeNG.
+#
+#  SmartHomeNG is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SmartHomeNG is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SmartHomeNG. If not, see <http://www.gnu.org/licenses/>.
+#########################################################################
+
+import logging
+import json
+import requests
+import html
+from lib.model.smartplugin import SmartPlugin
+
+
+class Slack(SmartPlugin):
+    PLUGIN_VERSION = "1.0.0"
+    ALLOW_MULTIINSTANCE = True
+    SLACK_INCOMING_WEBHOOK = 'https://hooks.slack.com/services/%s'
+
+    def __init__(self, sh):
+        self.logger = logging.getLogger(__name__)
+        self.logger.info("Init Slack notifications")
+        self._sh = sh
+        self.token = self.get_parameter_value('token')
+
+    def run(self):
+        pass
+
+    def stop(self):
+        pass
+
+    def _push(self, payload):
+        webhook = self.SLACK_INCOMING_WEBHOOK % self.token
+        try:
+            res = requests.post(webhook,
+                                headers={
+                                    "User-Agent": "sh.py",
+                                    "Content-Type": "application/json",
+                                    "Accept": "application/json"},
+                                timeout=4,
+                                data=payload,
+                                )
+            self.logger.debug(res)
+            response = res.text
+            del res
+            self.logger.debug(response)
+        except BaseException as e:
+            self.logger.exception(e)
+
+    def notify(self, channel, text, color='normal'):
+        color_choices = ['normal', 'good', 'warning', 'danger']
+        if color not in color_choices:
+            self.logger.error("Please choose a valid color from {}".format(','.join(color_choices)))
+            color = "normal"
+        payload = {}
+        if color == "normal" and text is not None:
+            payload = dict(text=html.escape(text, quote=False))
+        elif text is not None:
+            payload = dict(attachments=[dict(text=html.escape(text, quote=False), color=color, mrkdwn_in=["text"])])
+        if channel is not None:
+            if (channel[0] == '#') or (channel[0] == '@'):
+                payload['channel'] = channel
+            else:
+                payload['channel'] = '#' + channel
+
+        payload = json.dumps(payload)
+        self.logger.debug("Slack sending notification {}".format(payload))
+        self._push(payload)
+
+    def parse_item(self, item):
+        pass

--- a/slack/plugin.yaml
+++ b/slack/plugin.yaml
@@ -1,0 +1,66 @@
+# Metadata for the Smart-Plugin
+plugin:
+    # Global plugin attributes
+    type: web                 # plugin type (gateway, interface, protocol, system, web)
+    description:
+        de: 'Slack messaging Dienst'
+        en: 'Slack messaging service'
+    maintainer: rthill
+    tester: maddinador
+    state: develop
+    keywords: messaging
+#    documentation: https://github.com/smarthomeNG/smarthome/wiki/CLI-Plugin        # url of documentation (wiki) page
+#    support: https://knx-user-forum.de/forum/supportforen/smarthome-py
+
+    version: 1.0.0                # Plugin version
+    sh_minversion: 1.4            # minimum shNG version to use this plugin
+#    sh_maxversion:               # maximum shNG version to use this plugin (leave empty if latest)
+    multi_instance: True          # plugin supports multi instance
+    restartable: True             # restartable: yes
+    classname: Slack              # class containing the plugin
+
+parameters:
+    # Definition of parameters to be configured in etc/plugin.yaml
+    token:
+        type: str
+        description:
+            de: 'Slack-Token für den API-Zugriff auf einen oder mehrere Kanäle in einem Slack-Workspace'
+            en: 'Slack token for API access to one or more channels in a single Slack workspace'
+        mandatory: True
+
+item_attributes: NONE
+    # Definition of item attributes defined by this plugin
+
+plugin_functions:
+    # Definition of public functions defined by this plugin
+        notify:
+            type: foo
+            description:
+                de: 'Absetzen einer Messaging-Nachricht an den Slack Workspace'
+                en: 'send a messaging text to Slack workspace'
+            parameters:
+                channel:
+                    type: str
+                    description:
+                        de: 'Slack-Kanal, in den gepostet wird'
+                        en: 'Slack channel to be posted to'
+                    mandatory: True
+                text:
+                    type: str
+                    description:
+                        de: 'Text der Nachricht'
+                        en: 'text of your message'
+                    mandatory: True
+                color:
+                    type: str
+                    description:
+                        de: 'Typ der Nachricht (=Farbe)'
+                        en: 'type of message (=color)'
+                    mandatory: False
+                    default: 'normal'
+                    valid_list: 
+                        - 'normal'
+                        - 'good'
+                        - 'warning'
+                        - 'danger'
+


### PR DESCRIPTION
Made a mistake when switching rthill's fork from upstream:master to upstream:develop. @rthill: sorry for messing things up!
Thus I started a clean fork and re-added the slack dir and its three files.
Original discussion was at pull request #144 and shall be continued here.