### PR TITLE
Added logic of esf to items comparison

### DIFF
--- a/knx/Check_KNX.py
+++ b/knx/Check_KNX.py
@@ -125,8 +125,123 @@ if os.path.isfile(esf):
     # those defined in both should be cross checked for plausibility according to the data point types
     # eg. a 1-Bit in ETS should match a boolean in SmartHomeNG
 
+    out += nl+nl+"Folgende Items sind mit Bezug zu KNX konfiguriert:"+nl
+    out += "="*70+nl
+    
+    max_len_id = 0
     for item in sh.return_items():
-        pass
+        len_id = len(item.id())
+        if len_id > max_len_id:
+            max_len_id = len_id
+    
+    fmtStrg = "{0:<" + str(max_len_id) + "}"
+    
+    out += fmtStrg.format("item")
+    for ct in ("type", "dpt", "GA", "bindtype"):
+        out += sep + "{0:<10}".format(ct)
+    out += sep + "ETS Name"
+    out += nl
+    out += "-"*(max_len_id+98) +nl
+    
+    item_ga = {}
+    
+    for item in sh.return_items():
+        item_prefix = fmtStrg.format(item.id())
+        item_prefix += "{1}{0:>10}".format(item.type(), sep)
+            
+        if "knx_dpt" in item.conf:
+            item_prefix += "{1}{0:>10}".format(item.conf["knx_dpt"], sep)
+            item_num = 0
+            
+            for ct in ("knx_listen", "knx_init", "knx_cache", "knx_send", "knx_status", "knx_reply", "knx_poll"):
+                if ct in item.conf:
+                    ele = item.conf[ct]
+                    if isinstance(ele, list):
+                        for ga in ele:
+                            ets_name = ""
+                            if ga in ets_ga:
+                                ets_name = ets_ga.get(ga).get('name')
+                                if ets_name:
+                                    ets_name = " in ETS => {0}.{1}.{2}".format(ets_ga.get(ga).get('main'), ets_ga.get(ga).get('middle'), ets_name )
+                                else:
+                                    ets_name = " in ETS unbekannt"
+                            else:
+                                ets_name = " in ETS unbekannt"
+
+                            to_add = {
+                                'item_path':item.id(),
+                                'item_type':item.type(),
+                                'dpt':item.conf["knx_dpt"],
+                                'bind_type':ct}
+
+                            if ga not in item_ga:
+                                item_ga[ga] = []
+                            item_ga[ga].append(to_add)
+
+                            out += "{2}{1}{0:>10}{1}{3:<10}{1}{4}".format(ga, sep, item_prefix, ct, ets_name) + nl
+                            item_num += 1
+                    else:
+                        ga = ele
+
+                        ets_name = ""
+                        if ga in ets_ga:
+                            ets_name = ets_ga.get(ga).get('name')
+                            if ets_name:
+                                ets_name = " in ETS => {0}.{1}.{2}".format(ets_ga.get(ga).get('main'), ets_ga.get(ga).get('middle'), ets_name )
+                            else:
+                                ets_name = " in ETS unbekannt"
+                        else:
+                            ets_name = " in ETS unbekannt"
+
+                        to_add = {
+                            'item_path':item.id(),
+                            'item_type':item.type(),
+                            'dpt':item.conf["knx_dpt"],
+                            'bind_type':ct}
+
+                        if ga not in item_ga:
+                            item_ga[ga] = []
+                        item_ga[ga].append(to_add)
+                        
+                        out += "{2}{1}{0:>10}{1}{3:<10}{1}{4}".format(ga, sep, item_prefix, ct, ets_name) + nl
+                        item_num += 1
+            
+            if item_num == 0:
+                out += "{2}{1}{0:>10}{1}{3:<10}{1}{4}".format(" ", sep, item_prefix, "- undef -", " ") + nl
+                           
+
+    out += nl+nl+"Folgende GAs sind in ETS konfiguriert:"+nl
+    out += "="*70+nl
+    
+    max_len_ga = 0
+    max_len_ga_tp = 0
+    for ga in ets_ga:
+        len_ga = len(ets_ga.get(ga).get('name'))
+        len_ga_tp = len(ets_ga.get(ga).get('type'))
+        if len_ga > max_len_ga:
+            max_len_ga = len_ga
+        if len_ga_tp > max_len_ga_tp:
+            max_len_ga_tp = len_ga_tp
+    
+    fmt_string = "{0:>10}{1}{2:<"+str(max_len_ga)+"}{1}{3:<"+str(max_len_ga_tp)+"}{1}" 
+    
+    header = fmt_string.format("GA", sep, "ETS Name", "ETS Typ")    
+    header += "{5:>6} {0}{3:>10}{0}{4:>10}{0}{1:>10}{0}{2}".format(sep, "BindType", "Item", "DPT", "Type", "#Items") + nl
+    
+    out += header
+    out += "-" * len(header) + nl
+    
+    for ga in sorted(ets_ga):
+        ga_prefix = fmt_string.format(ga, sep, ets_ga.get(ga).get('name'), ets_ga.get(ga).get('type'))
+        
+        if ga in item_ga:
+            item_list = item_ga.get(ga)
+            item_list_len = len(item_list)
+            for it in item_list:
+                out += ga_prefix + "{5:>6} {0}{3:>10}{0}{4:>10}{0}{1:>10}{0}{2}".format(sep, it.get('bind_type'), it.get('item_path'), it.get('dpt'), it.get('item_type'), item_list_len) + nl
+        else:
+            out += ga_prefix + "{5:>6} {0}{3:>10}{0}{4:>10}{0}{1:>10}{0}{2}".format(sep, "knx_?", "NICHT ALS ITEM ANGELEGT", "N/A", "?", 0) + nl
+
 
     try:
         f = open(outfile, 'w')


### PR DESCRIPTION
Creates the following output at the end of the report. (Example lines only)

A type comparison has to be done manually e.g. in Excel. But with this output gaps/delta between ETS Configuration and Items can be easily spotted.

```
Folgende Items sind mit Bezug zu KNX konfiguriert:
======================================================================
item                                                             |type      |dpt       |GA        |bindtype  |ETS Name
-------------------------------------------------------------------------------------------------------------------------------------------------------------------
wurzel.zentral.klingelknopf                                 |      bool|         1|     0/3/5|knx_listen| in ETS => Globale Daten.Meldungen.Türklingel Klingeln
wurzel.zentral.klingelknopf                                 |      bool|         1|     0/3/5|knx_send  | in ETS => Globale Daten.Meldungen.Türklingel Klingeln

Folgende GAs sind in ETS konfiguriert:
======================================================================
        GA|ETS Name                                                         |ETS Typ                            |#Items |       DPT|      Type|  BindType|Item
----------------------------------------------------------------------------------------------------------------------------------------------------------------
    0/0/14|Gerätefehler Dimmaktor 4Kanal EG                                 |EIS 1 'Switching' (1 Bit)          |     1 |         1|      bool|knx_listen|wurzel.stoerungen.geraetefehlerDimmaktorEg
    0/0/15|Gerätefehler Dimmaktor 2Kanal EG                                 |EIS 1 'Switching' (1 Bit)          |     0 |       N/A|         ?|     knx_?|NICHT ALS ITEM ANGELEGT


```