### PR TITLE
Database: Add new countall function to get amount of log entries returned

### DIFF
--- a/database/__init__.py
+++ b/database/__init__.py
@@ -467,6 +467,7 @@ class Database(SmartPlugin):
             'avg': 'MIN(time), ' + self._precision_query('AVG(val_num * duration) / AVG(duration)'),
             'avg.order': 'ORDER BY time ASC',
             'count': 'MIN(time), SUM(CASE WHEN val_num{op}{value} THEN 1 ELSE 0 END)'.format(**expression['params']),
+            'countall' : 'MIN(time), COUNT(*)',
             'min': 'MIN(time), MIN(val_num)',
             'max': 'MIN(time), MAX(val_num)',
             'on': 'MIN(time), ' + self._precision_query('SUM(val_bool * duration) / SUM(duration)'),
@@ -515,6 +516,7 @@ class Database(SmartPlugin):
         queries = {
             'avg': self._precision_query('AVG(val_num * duration) / AVG(duration)'),
             'count': 'SUM(CASE WHEN val_num{op}{value} THEN 1 ELSE 0 END)'.format(**expression['params']),
+            'countall' : 'COUNT(*)',
             'min': 'MIN(val_num)',
             'max': 'MAX(val_num)',
             'on': self._precision_query('SUM(val_bool * duration) / SUM(duration)'),


### PR DESCRIPTION
This introduces a new function called `countall` to get the amount of log entries.
E.g. when you want to retrieve the amount of log entries for a given item you can use
```
item.db('countall', 0)      # return amount of entries with start-time=0 until now (= all)
item.db('countall', '-1w')  # return amount of entries with start-time=-1 week until now
```

Querying the values as series is also possible by using:
```
item.series('countall', '0')    # return amount with start-time=0 until now (= all), grouped by 100 entries (default) 
item.series('countall', '-1w')  # return amount with start-time=-1 week  until now, grouped by 100 entries (default) 
```
I'm not sure if this is really a use-case, but with this it would be possible to show the data increase in a chart for a time range and an absolute data count for a given item (e.g. can be used in admin interface, but also for users in their visualizations).

We could also decide to implement this as a plugin function (mainly used for internal purpose) if we only want to use this in the backend. This special case could also provide the values for all items (like 'select count(*), item_id from log group by item_id`), which is currently not implemented in this PR (the methods are currently item related).
