### PR TITLE
openweathermap: Add support for forecast data

### DIFF
--- a/openweathermap/README.md
+++ b/openweathermap/README.md
@@ -138,6 +138,149 @@ owm:
         uvi_date:
             type: num
             owm_matchstring@home: uvi_date
+
+        forecast_3hours: # next 3 hours, use 0-39 for further forecasts
+            time:
+                type: num
+                owm_matchstring@home: forecast/1/dt
+
+            conditions:
+                type: list
+                owm_matchstring@home: weather
+
+            temp:
+                type: num
+                owm_matchstring@home: forecast/1/main/temp
+
+            temp_min:
+                type: num
+                owm_matchstring@home: forecast/1/main/temp_min
+
+            temp_max:
+                type: num
+                owm_matchstring@home: forecast/1/main/temp_max
+
+            pressure:
+                type: num
+                owm_matchstring@home: forecast/1/main/pressure
+
+            grnd_level:
+                type: num
+                owm_matchstring@home: forecast/1/main/grnd_level
+
+            sea_level:
+                type: num
+                owm_matchstring@home: forecast/1/main/sea_level
+
+            humidity:
+                type: num
+                owm_matchstring@home: forecast/1/main/humidity
+
+            wind:
+                wind_speed:
+                    type: num
+                    owm_matchstring@home: forecast/1/wind/speed
+
+                wind_deg:
+                    type: num
+                    owm_matchstring@home: forecast/1/wind/deg
+
+            clouds:
+                type: num
+                owm_matchstring@home: forecast/1/clouds/all
+
+        forecast_daily0: # tomorrow's forecast
+            time:
+                type: num
+                owm_matchstring@home: forecast/daily/0/dt
+
+            temp:
+                type: num
+                owm_matchstring@home: forecast/daily/0/main/temp
+
+            temp_min:
+                type: num
+                owm_matchstring@home: forecast/daily/0/main/temp_min
+
+            temp_max:
+                type: num
+                owm_matchstring@home: forecast/daily/0/main/temp_max
+
+            pressure:
+                type: num
+                owm_matchstring@home: forecast/daily/0/main/pressure
+
+                grnd_level:
+                    type: num
+                    owm_matchstring@home: forecast/daily/0/main/grnd_level
+
+                sea_level:
+                    type: num
+                    owm_matchstring@home: forecast/daily/0/main/sea_level
+
+            humidity:
+                type: num
+                owm_matchstring@home: forecast/daily/0/main/humidity
+
+            wind:
+                wind_speed:
+                    type: num
+                    owm_matchstring@home: forecast/daily/0/wind/speed
+
+                wind_deg:
+                    type: num
+                    owm_matchstring@home: forecast/daily/0/wind/deg
+
+            clouds:
+                type: num
+                owm_matchstring@home: forecast/daily/0/clouds/all
+
+        forecast_daily1: # day after tomorrow (max index 4 = 5 days ahead)
+            time:
+                type: num
+                owm_matchstring@home: forecast/daily/1/dt
+
+            temp:
+                type: num
+                owm_matchstring@home: forecast/daily/1/main/temp
+
+            temp_min:
+                type: num
+                owm_matchstring@home: forecast/daily/1/main/temp_min
+
+            temp_max:
+                type: num
+                owm_matchstring@home: forecast/daily/1/main/temp_max
+
+            pressure:
+                type: num
+                owm_matchstring@home: forecast/daily/1/main/pressure
+
+            grnd_level:
+                type: num
+                owm_matchstring@home: forecast/daily/1/main/grnd_level
+
+            sea_level:
+                type: num
+                owm_matchstring@home: forecast/daily/1/main/sea_level
+
+            humidity:
+                type: num
+                owm_matchstring@home: forecast/daily/1/main/humidity
+
+            wind:
+                wind_speed:
+                    type: num
+                    owm_matchstring@home: forecast/daily/1/wind/speed
+
+                wind_deg:
+                    type: num
+                    owm_matchstring@home: forecast/daily/1/wind/deg
+
+            clouds:
+                type: num
+                owm_matchstring@home: forecast/daily/1/clouds/all
+
 ```
 
 ### logic.yaml

--- a/openweathermap/__init__.py
+++ b/openweathermap/__init__.py
@@ -26,6 +26,8 @@ import logging
 import requests
 import datetime
 import json
+import functools
+from datetime import datetime, timedelta, timezone
 from lib.module import Modules
 from lib.model.smartplugin import *
 from bin.smarthome import VERSION
@@ -82,48 +84,29 @@ class OpenWeatherMap(SmartPlugin):
         Updates information on diverse items
         """
         weather = self.get_weather()
+        forecast = self.get_forecast()
         uv = self.get_uv()
 
         self._jsonData['weather'] = weather
+        self._jsonData['forecast'] = forecast
         self._jsonData['uvi'] = uv
         for s, item in self._items.items():
 
             if s in ['clouds_new', 'precipitation_new', 'pressure_new', 'wind_new', 'temp_new']:
                 wrk = self.get_owm_layer(item)
+            elif s.startswith('forecast/daily/'):
+                wrk = self.get_daily_forecast(s)
             else:
-                if 'uvi' not in s:
-                    wrk = weather
-                else:
+                if s.startswith('forecast/'):
+                    wrk = forecast
+                    s = s.replace("forecast/", "list/")
+                elif 'uvi' in s:
                     wrk = uv
                     s = s.replace("uvi_", "")
-                sp = s.split('/')
+                else:
+                    wrk = weather
 
-                while True:
-                    if (len(sp) == 0) or (wrk is None):
-                        break
-                    if type(wrk) is list:
-                        if self.is_int(sp[0]):
-                            if int(sp[0]) < len(wrk):
-                                wrk = wrk[int(sp[0])]
-                            else:
-                                self.logger.error(
-                                    "_update: invalid owm_matchstring '{}'; integer too large in matchstring".format(
-                                        s))
-                                break
-                        else:
-                            self.logger.error(
-                                "_update: invalid owm_matchstring '{}'; integer expected in matchstring".format(
-                                    s))
-                            break
-                    else:
-                        wrk = wrk.get(sp[0])
-                    if len(sp) == 1:
-                        spl = s.split('/')
-                        self.logger.debug(
-                            "_update: owm_matchstring split len={}, content={} -> '{}'".format(str(len(spl)),
-                                                                                               str(spl),
-                                                                                               str(wrk)))
-                    sp.pop(0)
+                wrk = self.get_val_from_dict(s, wrk)
 
             # if a value was found, store it to item
             if wrk is not None:
@@ -132,11 +115,101 @@ class OpenWeatherMap(SmartPlugin):
 
         return
 
+    def get_val_from_dict(self, s, wrk):
+        """
+        Uses string s as a path to navigate to the requested value in dict wrk.
+        """
+        sp = s.split('/')
+        while True:
+            if (len(sp) == 0) or (wrk is None):
+                break
+            if type(wrk) is list:
+                if self.is_int(sp[0]):
+                    if int(sp[0]) < len(wrk):
+                        wrk = wrk[int(sp[0])]
+                    else:
+                        self.logger.error(
+                            "_update: invalid owm_matchstring '{}'; integer too large in matchstring".format(
+                                s))
+                        break
+                else:
+                    self.logger.error(
+                        "_update: invalid owm_matchstring '{}'; integer expected in matchstring".format(
+                            s))
+                    break
+            else:
+                wrk = wrk.get(sp[0])
+            if len(sp) == 1:
+                spl = s.split('/')
+                self.logger.debug(
+                    "_update: owm_matchstring split len={}, content={} -> '{}'".format(str(len(spl)),
+                                                                                       str(spl),
+                                                                                       str(wrk)))
+            sp.pop(0)
+        return wrk
+
     def get_owm_layer(self, item):
         """
         Requests the layer information (image links) at openweathermap.com
         """
         return self._build_url('owm_layer', item)
+
+    def get_daily_forecast(self, s):
+        """
+        Calculates daily forecast from (free) 3-hours data.
+        This builds the average/min/max of all available 3-hour entries that match the
+        requested period (1, 2, ..., 5 days in the future).
+        Uses local time to determine which entries to include/exclude.
+        """
+        s = s.replace("forecast/daily/", "")
+        forecast = self._jsonData['forecast']
+        #print("!!! forecast:")
+        date_current = datetime.now()
+        #print("current: " + str(date_current))
+        date_requested = datetime(date_current.year, date_current.month, date_current.day)
+        sp = s.split('/')
+        if self.is_int(sp[0]):
+            days_in_future = int(sp[0]) + 1
+            date_requested = date_requested + timedelta(days=days_in_future)
+            sp.pop(0)
+        else:
+            self.logger.error(
+                "_update: invalid owm_matchstring '{}'; integer expected after forecast/daily/ matchstring".format(
+                    s))
+            return None
+
+        #print("requested: " + date_requested.strftime('%Y-%m-%d %H:%M:%S'))
+
+        too_far = date_requested + timedelta(days=1)
+
+        wrk = []
+        #print("calculating: " + s)
+        for entry in forecast.get('list'):
+            dt = int(entry.get('dt'))
+            if dt >= int(too_far.timestamp()):
+                break
+            if dt >= int(date_requested.timestamp()):
+                val = self.get_val_from_dict("/".join(sp), entry)
+                if isinstance(val, float) or isinstance(val,int):
+                    #print("value: " + str(val))
+                    wrk.append(val)
+                elif val is None:
+                    self.logger.error("_update: found None value while calculating daily forecast for matchstring '{}'.".format(s))
+                    return 0
+                else:
+                    #print("type: "+ str(type(val)))
+                    self.logger.error("_update: found unknown value while calculating daily forecast for matchstring '{}'; daily forecast only supported for int and float.".format(s))
+                    return 0
+                #print("including " + datetime.fromtimestamp(dt).strftime('%Y-%m-%d %H:%M:%S') + ", value: " + str(val))
+
+        result = 0
+        if "max" in sp[len(sp)-1]:
+            result = max(wrk)
+        elif "min" in sp[len(sp)-1]:
+            result = min(wrk)
+        else: #average
+            result = round(functools.reduce(lambda x, y: x + y, wrk) / len(wrk), 2)
+        return result
 
     def get_weather(self):
         """
@@ -147,6 +220,19 @@ class OpenWeatherMap(SmartPlugin):
         except Exception as e:
             self.logger.error(
                 "get_weather: Exception when sending GET request for get_weather: %s" % str(e))
+            return
+        json_obj = response.json()
+        return json_obj
+
+    def get_forecast(self):
+        """
+        Requests the 5-days forecast information at openweathermap.com
+        """
+        try:
+            response = self._session.get(self._build_url('forecast'))
+        except Exception as e:
+            self.logger.error(
+                "get_weather: Exception when sending GET request for get_forecast: %s" % str(e))
             return
         json_obj = response.json()
         return json_obj
@@ -197,6 +283,11 @@ class OpenWeatherMap(SmartPlugin):
         url = ''
         if url_type == 'weather':
             url = self._base_url % 'data/2.5/weather'
+            parameters = "?lat=%s&lon=%s&appid=%s&lang=%s&units=%s" % (self._lat, self._lon, self._key, self._lang,
+                                                                       self._units)
+            url = '%s%s' % (url, parameters)
+        elif url_type == 'forecast':
+            url = self._base_url % 'data/2.5/forecast'
             parameters = "?lat=%s&lon=%s&appid=%s&lang=%s&units=%s" % (self._lat, self._lon, self._key, self._lang,
                                                                        self._units)
             url = '%s%s' % (url, parameters)

--- a/openweathermap/__init__.py
+++ b/openweathermap/__init__.py
@@ -163,10 +163,8 @@ class OpenWeatherMap(SmartPlugin):
         """
         s = s.replace("forecast/daily/", "")
         forecast = self._jsonData['forecast']
-        #print("!!! forecast:")
-        date_current = datetime.now()
-        #print("current: " + str(date_current))
-        date_requested = datetime(date_current.year, date_current.month, date_current.day)
+        datetime_now = datetime.now()
+        date_requested = datetime(datetime_now.year, datetime_now.month, datetime_now.day)
         sp = s.split('/')
         if self.is_int(sp[0]):
             days_in_future = int(sp[0]) + 1
@@ -178,12 +176,8 @@ class OpenWeatherMap(SmartPlugin):
                     s))
             return None
 
-        #print("requested: " + date_requested.strftime('%Y-%m-%d %H:%M:%S'))
-
         too_far = date_requested + timedelta(days=1)
-
         wrk = []
-        #print("calculating: " + s)
         for entry in forecast.get('list'):
             dt = int(entry.get('dt'))
             if dt >= int(too_far.timestamp()):
@@ -191,16 +185,13 @@ class OpenWeatherMap(SmartPlugin):
             if dt >= int(date_requested.timestamp()):
                 val = self.get_val_from_dict("/".join(sp), entry)
                 if isinstance(val, float) or isinstance(val,int):
-                    #print("value: " + str(val))
                     wrk.append(val)
                 elif val is None:
                     self.logger.error("_update: found None value while calculating daily forecast for matchstring '{}'.".format(s))
                     return 0
                 else:
-                    #print("type: "+ str(type(val)))
                     self.logger.error("_update: found unknown value while calculating daily forecast for matchstring '{}'; daily forecast only supported for int and float.".format(s))
                     return 0
-                #print("including " + datetime.fromtimestamp(dt).strftime('%Y-%m-%d %H:%M:%S') + ", value: " + str(val))
 
         result = 0
         if "max" in sp[len(sp)-1]:


### PR DESCRIPTION
This allows the openweathermap plugin to use the free API for forecasts.
Forecasts are received as 40 distinct 3-hours timeslices.
To provide daily forecasts, the average/min/max of those 3-hours slices is calculated.

The forecast is matched by using "forecast/x/" where x is between 0-39 and indicates the index of the 3-hour prediction from the API.

Daily forecasts are matched by using "forecast/daily/x" where x is "days-in-future - 1", so it ranges from 0-4. (We don't have complete forecast data for the current day)

Up for discussion:
- Use daily index 0 for current day, even if it is possible we have NO prediction (e.g. if forecast was requested at 22.00 the first prediction is already for the next day)?
- Is it okay for you to assume that "the temperature" is the average of all available 3-hour predictions?
- While calculating an average temperature makes (some) sense, average wind direction may not
- The fifths day (daily/4) will not have a complete forecast, as the last timeslice available will be at the current time +4 days

This commit currently includes commented-out debug prints that i will of course remove when we're ready.