### PR TITLE
Mailrcv plugin: Added option to change name of trash and fixed a problem occuring when decoding emails

### DIFF
--- a/mailrcv/__init__.py
+++ b/mailrcv/__init__.py
@@ -31,7 +31,7 @@ class IMAP(SmartPlugin):
     ALLOW_MULTIINSTANCE = True
     PLUGIN_VERSION = "1.4.0"
 
-    def __init__(self, smarthome, host, username, password, cycle=300, port=993, tls=True):
+    def __init__(self, smarthome, host, username, password, cycle=300, port=993, tls=True, trashfolder="Trash"):
         self._sh = smarthome
         self._host = host
         self._port = port
@@ -42,6 +42,7 @@ class IMAP(SmartPlugin):
         self._mail_to = {}
         self._mail = False
         self._tls = self.to_bool(tls)
+        self._trashfolder = trashfolder
         if '.'.join(VERSION.split('.', 2)[:2]) <= '1.5':
             self.logger = logging.getLogger(__name__)
 
@@ -128,12 +129,15 @@ class IMAP(SmartPlugin):
                     else:
                         logger.warning("Could not move mail to trash. {0} => {1}: {2}".format(fo, to, subject))
                 else:
-                    rsp, data = imap.uid('copy', uid, 'Trash')
+                    rsp, data = imap.uid('copy', uid, self._trashfolder)
                     if rsp == 'OK':
                         typ, data = imap.uid('store', uid, '+FLAGS', '(\Deleted)')
                         self.logger.debug("Moving mail to trash. {0} => {1}: {2}".format(fo, to, subject))
                     else:
                         self.logger.warning("Could not move mail to trash. {0} => {1}: {2}".format(fo, to, subject))
+                        self.logger.info("Consider setting the trashfolder option to the name of your trash mailbox. Available mailboxes are:")
+                        for mb in imap.list()[1]:
+                            self.logger.info(mb.decode("utf-8"))
             else:
                 self.logger.info("Ignoring mail. {0} => {1}: {2}".format(fo, to, subject))
         imap.close()

--- a/mailrcv/__init__.py
+++ b/mailrcv/__init__.py
@@ -29,7 +29,7 @@ from bin.smarthome import VERSION
 
 class IMAP(SmartPlugin):
     ALLOW_MULTIINSTANCE = True
-    PLUGIN_VERSION = "1.4.0"
+    PLUGIN_VERSION = "1.4.1"
 
     def __init__(self, smarthome, *args, **kwargs): #host, username, password, cycle=300, port=993, tls=True, trashfolder="Trash"):
         self._sh = smarthome

--- a/mailrcv/__init__.py
+++ b/mailrcv/__init__.py
@@ -31,18 +31,19 @@ class IMAP(SmartPlugin):
     ALLOW_MULTIINSTANCE = True
     PLUGIN_VERSION = "1.4.1"
 
-    def __init__(self, smarthome, host, username, password, cycle=300, port=993, tls=True, trashfolder="Trash"):
+    def __init__(self, smarthome, *args, **kwargs):
         self._sh = smarthome
-        self._host = host
-        self._port = port
-        self._username = username
-        self._password = password
-        self.cycle = int(cycle)
+        self._host = self.get_parameter_value('host')
+        self._port = self.get_parameter_value('port')
+        self._username = self.get_parameter_value('username')
+        self._password = self.get_parameter_value('password')
+        self.cycle = self.get_parameter_value('cycle')
+        self._tls = self.get_parameter_value('tls')
+        self._trashfolder = self.get_parameter_value('trashfolder')
         self._mail_sub = {}
         self._mail_to = {}
         self._mail = False
-        self._tls = self.to_bool(tls)
-        self._trashfolder = trashfolder
+
         if '.'.join(VERSION.split('.', 2)[:2]) <= '1.5':
             self.logger = logging.getLogger(__name__)
 

--- a/mailrcv/__init__.py
+++ b/mailrcv/__init__.py
@@ -31,8 +31,7 @@ class IMAP(SmartPlugin):
     ALLOW_MULTIINSTANCE = True
     PLUGIN_VERSION = "1.4.1"
 
-    def __init__(self, smarthome, *args, **kwargs):
-        self._sh = smarthome
+    def __init__(self, sh, *args, **kwargs):
         self._host = self.get_parameter_value('host')
         self._port = self.get_parameter_value('port')
         self._username = self.get_parameter_value('username')
@@ -146,7 +145,7 @@ class IMAP(SmartPlugin):
 
     def run(self):
         self.alive = True
-        self._sh.scheduler.add('IMAP', self._cycle, cycle=self.cycle)
+        self.scheduler_add('IMAP', self._cycle, cycle=self.cycle)
 
     def stop(self):
         self.alive = False

--- a/mailrcv/__init__.py
+++ b/mailrcv/__init__.py
@@ -31,40 +31,33 @@ class IMAP(SmartPlugin):
     ALLOW_MULTIINSTANCE = True
     PLUGIN_VERSION = "1.4.0"
 
-    def __init__(self, smarthome, host, username, password, cycle=300, port=993, tls=True, trashfolder="Trash"):
+    def __init__(self, smarthome, *args, **kwargs): #host, username, password, cycle=300, port=993, tls=True, trashfolder="Trash"):
         self._sh = smarthome
-        self._host = host
-        self._port = port
-        self._username = username
-        self._password = password
-        self.cycle = int(cycle)
         self._mail_sub = {}
         self._mail_to = {}
         self._mail = False
-        self._tls = self.to_bool(tls)
-        self._trashfolder = trashfolder
         if '.'.join(VERSION.split('.', 2)[:2]) <= '1.5':
             self.logger = logging.getLogger(__name__)
 
     def _connect(self):
-        if self._tls:
-            if self._port is not None:
-                imap = imaplib.IMAP4_SSL(self._host, self._port)
+        if self.get_parameter_value('tls'):
+            if self.get_parameter_value('port') is not None:
+                imap = imaplib.IMAP4_SSL(self.get_parameter_value('host'), self.get_parameter_value('port'))
             else:
-                imap = imaplib.IMAP4_SSL(self._host)
+                imap = imaplib.IMAP4_SSL(self.get_parameter_value('host'))
         else:
-            if self._port is not None:
-                imap = imaplib.IMAP4(self._host, self._port)
+            if self.get_parameter_value('port') is not None:
+                imap = imaplib.IMAP4(self.get_parameter_value('host'), self.get_parameter_value('port'))
             else:
-                imap = imaplib.IMAP4(self._host)
-        imap.login(self._username, self._password)
+                imap = imaplib.IMAP4(self.get_parameter_value('host'))
+        imap.login(self.get_parameter_value('username'), self.get_parameter_value('password'))
         return imap
 
     def _cycle(self):
         try:
             imap = self._connect()
         except Exception as e:
-            self.logger.warning("Could not connect to {0}: {1}".format(self._host, e))
+            self.logger.warning("Could not connect to {0}: {1}".format(self.get_parameter_value('host'), e))
             return
         rsp, data = imap.select()
         if rsp != 'OK':
@@ -122,14 +115,14 @@ class IMAP(SmartPlugin):
                 logic = False
             if logic:
                 logic.trigger('IMAP', fo, mail, dest=to)
-                if self._host.lower() == 'imap.gmail.com':
+                if self.get_parameter_value('host').lower() == 'imap.gmail.com':
                     typ, data = imap.uid('store', uid, '+X-GM-LABELS', '\\Trash')
                     if typ == 'OK':
-                        logger.debug("Moving mail to trash. {0} => {1}: {2}".format(fo, to, subject))
+                        self.logger.debug("Moving mail to trash. {0} => {1}: {2}".format(fo, to, subject))
                     else:
-                        logger.warning("Could not move mail to trash. {0} => {1}: {2}".format(fo, to, subject))
+                        self.logger.warning("Could not move mail to trash. {0} => {1}: {2}".format(fo, to, subject))
                 else:
-                    rsp, data = imap.uid('copy', uid, self._trashfolder)
+                    rsp, data = imap.uid('copy', uid, self.get_parameter_value('trashfolder'))
                     if rsp == 'OK':
                         typ, data = imap.uid('store', uid, '+FLAGS', '(\Deleted)')
                         self.logger.debug("Moving mail to trash. {0} => {1}: {2}".format(fo, to, subject))
@@ -145,7 +138,7 @@ class IMAP(SmartPlugin):
 
     def run(self):
         self.alive = True
-        self._sh.scheduler.add('IMAP', self._cycle, cycle=self.cycle)
+        self._sh.scheduler.add('IMAP', self._cycle, cycle=self.get_parameter_value('cycle'))
 
     def stop(self):
         self.alive = False

--- a/mailrcv/__init__.py
+++ b/mailrcv/__init__.py
@@ -93,6 +93,10 @@ class IMAP(SmartPlugin):
                         self.logger.warning("IMAP: problem getting message {} from data: data-list has length {} and data[0] = '{}'".format(uid, len(data), data[0]))
                     if len(data) > 1:
                         self.logger.warning("data[1] = '{}'".format(data[1]))
+                # If a (non standard-conforming) mail without content-transfer-encoding is received, decoding the mail content fails.
+                # In this case we set the encoding to the official standard, which should be a good guess.
+                if not 'content-transfer-encoding' in mail:
+                    mail['content-transfer-encoding'] = '7BIT'
                 to = email.utils.parseaddr(mail['To'])[1]
                 fo = email.utils.parseaddr(mail['From'])[1]
                 if mail['Subject'] is None:

--- a/mailrcv/plugin.yaml
+++ b/mailrcv/plugin.yaml
@@ -71,7 +71,7 @@ parameters:
         type: str
         default: 'Trash'
         description:
-            de: 'Name des Müll-Ordners auf dem IMAP-Server'
+            de: 'Name des MÃ¼ll-Ordners auf dem IMAP-Server'
             en: 'Name of the trashfolder on the IMAP-Server'
 
 item_attributes: NONE

--- a/mailrcv/plugin.yaml
+++ b/mailrcv/plugin.yaml
@@ -12,7 +12,7 @@ plugin:
 #    documentation: https://github.com/smarthomeNG/smarthome/wiki/CLI-Plugin        # url of documentation (wiki) page
 #    support: https://knx-user-forum.de/forum/supportforen/smarthome-py
 
-    version: 1.4.0                 # Plugin version
+    version: 1.4.1                 # Plugin version
     sh_minversion: 1.4             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True           # plugin supports multi instance

--- a/mailrcv/plugin.yaml
+++ b/mailrcv/plugin.yaml
@@ -66,6 +66,13 @@ parameters:
         description:
             de: 'Passwort fÃ¼r die Anmeldung am IMAP host'
             en: 'Password for login to the IMAP host'
+            
+    trashfolder:
+        type: str
+        default: 'Trash'
+        description:
+            de: 'Name des Müll-Ordners auf dem IMAP-Server'
+            en: 'Name of the trashfolder on the IMAP-Server'
 
 item_attributes: NONE
     # Definition of item attributes defined by this plugin


### PR DESCRIPTION
This PR contains of two small bugfixes:

**Trashfoder option:** 
Depending on the configuration of the IMAP server, the Trash folder can have different names.
To move a read mail to trash, the mailplugin has to know that name. Added the possibility to change
the name of the trashfolder.

If deleting the mail fails a list of abailable folders is written to the log.

**Emails without content-transfer-encoding header**
According to RF1341, emails can but must not contain the content-transfer-encoding header. (https://www.w3.org/Protocols/rfc1341/5_Content-Transfer-Encoding.html).
If this header does not exist, the python email package does not allow decoding of the message (at least in some versions).

To resolve this we simply set the content-transfer-encoding header to 7BIT, which is the default, if it does not exist.
