### PR TITLE
Fix class name

### DIFF
--- a/alexa/plugin.yaml
+++ b/alexa/plugin.yaml
@@ -16,7 +16,7 @@ plugin:
     sh_minversion: 1.3             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
-    classname: Alexa               # class containing the plugin
+    class_name: Alexa               # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/alexa4p3/plugin.yaml
+++ b/alexa4p3/plugin.yaml
@@ -13,7 +13,7 @@ plugin:
     version: 1.0.1                   # Plugin version
     sh_minversion: 1.3               # minimum shNG version to use this plugin
     multi_instance: False            # plugin supports multi instance
-    classname: alexa4p3              # class containing the plugin
+    class_name: alexa4p3              # class containing the plugin
     state: develop                   # State of the Plugin
     restartable: True                # Plugin is restartable 
 

--- a/alexa4p3/plugin.yaml
+++ b/alexa4p3/plugin.yaml
@@ -13,7 +13,7 @@ plugin:
     version: 1.0.1                   # Plugin version
     sh_minversion: 1.3               # minimum shNG version to use this plugin
     multi_instance: False            # plugin supports multi instance
-    class_name: alexa4p3              # class containing the plugin
+    class_name: Alexa4P3              # class containing the plugin
     state: develop                   # State of the Plugin
     restartable: True                # Plugin is restartable 
 

--- a/alexa4p3/service.py
+++ b/alexa4p3/service.py
@@ -339,7 +339,7 @@ class AlexaRequestHandler(BaseHTTPRequestHandler):
                 appliance = {
                     "endpointId": device.id,
                     "friendlyName": device.name,
-                    "description": "SmartHomeNG",
+                    "friendlyDescription": device.description,
                     "manufacturerName": "SmarthomeNG",
                     "displayCategories": 
                         device.icon,

--- a/apcups/plugin.yaml
+++ b/apcups/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True           # plugin supports multi instance
     restartable: unknown
-    classname: APCUPS              # class containing the plugin
+    class_name: APCUPS              # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/appletv/__init__.py
+++ b/appletv/__init__.py
@@ -365,7 +365,7 @@ class AppleTV(SmartPlugin):
         self.mod_http.register_webif(WebInterface(webif_dir, self), 
                                      self.get_shortname(), 
                                      config, 
-                                     self.get_classname(), self.get_instance_name(),
+                                     self.get_class_name(), self.get_instance_name(),
                                      description='')
                                    
         return True

--- a/appletv/plugin.yaml
+++ b/appletv/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
     sh_minversion: 1.4              # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True            # plugin supports multi instance
-    classname: AppleTV              # class containing the plugin
+    class_name: AppleTV              # class containing the plugin
 
 parameters:
     ip:

--- a/artnet/__init__.py
+++ b/artnet/__init__.py
@@ -309,7 +309,7 @@ class ArtNet(SmartPlugin):
         self.mod_http.register_webif(WebInterface(webif_dir, self),
                                      self.get_shortname(),
                                      config,
-                                     self.get_classname(), self.get_instance_name(),
+                                     self.get_class_name(), self.get_instance_name(),
                                      description='')
 
         return True

--- a/artnet/plugin.yaml
+++ b/artnet/plugin.yaml
@@ -16,7 +16,7 @@ plugin:
 #   sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True
     restartable: True              # Plugin can be restarted safely, however, the data is not re-applied from items to the DMX-Values
-    classname: ArtNet              # class containing the plugin
+    class_name: ArtNet              # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/asterisk/plugin.yaml
+++ b/asterisk/plugin.yaml
@@ -16,7 +16,7 @@ plugin:
     sh_minversion: 1.3             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
-    classname: Asterisk            # class containing the plugin
+    class_name: Asterisk            # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/avdevice/__init__.py
+++ b/avdevice/__init__.py
@@ -3082,7 +3082,7 @@ class AVDevice(SmartPlugin):
         self.mod_http.register_webif(WebInterface(webif_dir, self),
                                      self.get_shortname(),
                                      config,
-                                     self.get_classname(), self.get_instance_name(),
+                                     self.get_class_name(), self.get_instance_name(),
                                      description='')
 
         return True

--- a/avdevice/_pv_1_3_2/plugin.yaml
+++ b/avdevice/_pv_1_3_2/plugin.yaml
@@ -15,7 +15,7 @@ plugin:
     sh_minversion: 1.3             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True          # plugin supports multi instance
-    classname: AVDevice            # class containing the plugin
+    class_name: AVDevice            # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/avdevice/_pv_1_3_3/plugin.yaml
+++ b/avdevice/_pv_1_3_3/plugin.yaml
@@ -15,7 +15,7 @@ plugin:
     sh_minversion: 1.3             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True          # plugin supports multi instance
-    classname: AVDevice            # class containing the plugin
+    class_name: AVDevice            # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/avdevice/_pv_1_3_4/plugin.yaml
+++ b/avdevice/_pv_1_3_4/plugin.yaml
@@ -15,7 +15,7 @@ plugin:
     sh_minversion: 1.3             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True          # plugin supports multi instance
-    classname: AVDevice            # class containing the plugin
+    class_name: AVDevice            # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/avdevice/_pv_1_3_5/plugin.yaml
+++ b/avdevice/_pv_1_3_5/plugin.yaml
@@ -15,7 +15,7 @@ plugin:
     sh_minversion: 1.3             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True          # plugin supports multi instance
-    classname: AVDevice            # class containing the plugin
+    class_name: AVDevice            # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/avdevice/_pv_1_3_6/plugin.yaml
+++ b/avdevice/_pv_1_3_6/plugin.yaml
@@ -15,7 +15,7 @@ plugin:
     sh_minversion: 1.3             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True          # plugin supports multi instance
-    classname: AVDevice            # class containing the plugin
+    class_name: AVDevice            # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/avdevice/plugin.yaml
+++ b/avdevice/plugin.yaml
@@ -36,7 +36,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True          # plugin supports multi instance
     restartable: unknown
-    classname: AVDevice            # class containing the plugin
+    class_name: AVDevice            # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/avm/__init__.py
+++ b/avm/__init__.py
@@ -2392,7 +2392,7 @@ class AVM(SmartPlugin):
         self.mod_http.register_webif(WebInterface(webif_dir, self),
                                      self.get_shortname(),
                                      config,
-                                     self.get_classname(), self.get_instance_name(),
+                                     self.get_class_name(), self.get_instance_name(),
                                      description='')
 
         return True

--- a/avm/plugin.yaml
+++ b/avm/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True           # plugin supports multi instance
     restartable: True
-    classname: AVM                 # class containing the plugin
+    class_name: AVM                 # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/backend/BackendPlugins.py
+++ b/backend/BackendPlugins.py
@@ -95,7 +95,7 @@ class BackendPlugins:
                 plugin['configname'] = x.get_configname()
                 plugin['shortname'] = x.get_shortname()
                 plugin['classpath'] = x._classpath
-                plugin['classname'] = x.get_classname()
+                plugin['class_name'] = x.get_class_name()
             else:
                 plugin['attributes'] = {}
                 plugin['smartplugin'] = False
@@ -103,7 +103,7 @@ class BackendPlugins:
                 plugin['configname'] = x._configname
                 plugin['shortname'] = x._shortname
                 plugin['classpath'] = x._classpath
-                plugin['classname'] = x._classname
+                plugin['class_name'] = x._class_name
                 plugin['stopped'] = False
 
             try:

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -170,7 +170,7 @@ class BackendServer(SmartPlugin):
         self.mod_http.register_webif(WebInterface(webif_dir, self), 
                                      self.get_shortname(), 
                                      config, 
-                                     self.get_classname(), self.get_instance_name(),
+                                     self.get_class_name(), self.get_instance_name(),
                                      description='Administrationsoberfläche für SmartHomeNG',
                                      webifname='')
                                    

--- a/backend/_pv_1_4_9/BackendPlugins.py
+++ b/backend/_pv_1_4_9/BackendPlugins.py
@@ -78,12 +78,12 @@ class BackendPlugins:
                 plugin['version'] = x.get_version()
                 plugin['shortname'] = x.get_shortname()
                 plugin['classpath'] = x._classpath
-                plugin['classname'] = x.get_classname()
+                plugin['class_name'] = x.get_class_name()
             else:
                 plugin['smartplugin'] = False
                 plugin['shortname'] = x._shortname
                 plugin['classpath'] = x._classpath
-                plugin['classname'] = x._classname
+                plugin['class_name'] = x._class_name
             
             if  plugin['shortname'] in ['cli','blockly']:
                 plugin['stopped'] = True

--- a/backend/_pv_1_4_9/__init__.py
+++ b/backend/_pv_1_4_9/__init__.py
@@ -172,7 +172,7 @@ class BackendServer(SmartPlugin):
         self.mod_http.register_webif(WebInterface(webif_dir, self), 
                                      self.get_shortname(), 
                                      config, 
-                                     self.get_classname(), self.get_instance_name(),
+                                     self.get_class_name(), self.get_instance_name(),
                                      description='Administrationsoberfläche für SmartHomeNG',
                                      webifname='')
                                    

--- a/backend/_pv_1_4_9/plugin.yaml
+++ b/backend/_pv_1_4_9/plugin.yaml
@@ -16,7 +16,7 @@ plugin:
     sh_minversion: 1.4.1           # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
-    classname: BackendServer       # class containing the plugin
+    class_name: BackendServer       # class containing the plugin
     
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/backend/plugin.yaml
+++ b/backend/plugin.yaml
@@ -58,7 +58,7 @@ plugin:
 #    sh_maxversion:                # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
     restartable: False
-    classname: BackendServer       # class containing the plugin
+    class_name: BackendServer       # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/blockly/__init__.py
+++ b/blockly/__init__.py
@@ -172,7 +172,7 @@ class Blockly(SmartPlugin):
         self.mod_http.register_webif(WebInterface(webif_dir, self), 
                                      self.get_shortname(), 
                                      config, 
-                                     self.get_classname(), self.get_instance_name(),
+                                     self.get_class_name(), self.get_instance_name(),
                                      description='Blockly graphical logics editor for SmartHomeNG',
                                      webifname='')
                                    

--- a/blockly/plugin.yaml
+++ b/blockly/plugin.yaml
@@ -18,7 +18,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
     restartable: unknown
-    classname: Blockly             # class containing the plugin
+    class_name: Blockly             # class containing the plugin
 
 
 parameters:

--- a/boxcar/plugin.yaml
+++ b/boxcar/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_minversion: 1.3             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
 #    multi_instance: False
-    classname: Boxcar               # class containing the plugin
+    class_name: Boxcar               # class containing the plugin
 
 #parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/buderus/plugin.yaml
+++ b/buderus/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
     sh_minversion: 1.1             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
-    classname: Buderus             # class containing the plugin
+    class_name: Buderus             # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/cli/_pv_1_3_0/plugin.yaml
+++ b/cli/_pv_1_3_0/plugin.yaml
@@ -15,7 +15,7 @@ plugin:
     sh_minversion: 1.3             # minimum shNG version to use this plugin
     sh_maxversion: 1.3c            # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
-    classname: CLI                 # class containing the plugin
+    class_name: CLI                 # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/cli/plugin.yaml
+++ b/cli/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
     restartable: unknown
-    classname: CLI                 # class containing the plugin
+    class_name: CLI                 # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/co2meter/plugin.yaml
+++ b/co2meter/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
     restartable: unknown
-    classname: CO2Meter            # class containing the plugin
+    class_name: CO2Meter            # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/comfoair/plugin.yaml
+++ b/comfoair/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False
     restartable: unknown
-    classname: ComfoAir             # class containing the plugin
+    class_name: ComfoAir             # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/darksky/__init__.py
+++ b/darksky/__init__.py
@@ -318,7 +318,7 @@ class DarkSky(SmartPlugin):
         self.mod_http.register_webif(WebInterface(webif_dir, self),
                                      self.get_shortname(),
                                      config,
-                                     self.get_classname(), self.get_instance_name(),
+                                     self.get_class_name(), self.get_instance_name(),
                                      description='')
 
         return True

--- a/darksky/plugin.yaml
+++ b/darksky/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:               # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True          # plugin supports multi instance
     restartable: True
-    classname: DarkSky            # class containing the plugin
+    class_name: DarkSky            # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/dashbutton/plugin.yaml
+++ b/dashbutton/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
     restartable: unknown
-    classname: Dashbutton          # class containing the plugin
+    class_name: Dashbutton          # class containing the plugin
 
 parameters: NONE
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/database/__init__.py
+++ b/database/__init__.py
@@ -718,7 +718,7 @@ class Database(SmartPlugin):
         self.mod_http.register_webif(WebInterface(webif_dir, self),
                                      self.get_shortname(),
                                      config,
-                                     self.get_classname(), self.get_instance_name(),
+                                     self.get_class_name(), self.get_instance_name(),
                                      description='')
 
         return True

--- a/database/plugin.yaml
+++ b/database/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True           # plugin supports multi instance
     restartable: unknown
-    classname: Database            # class containing the plugin
+    class_name: Database            # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/datalog/plugin.yaml
+++ b/datalog/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True
     restartable: unknown
-    classname: DataLog              # class containing the plugin
+    class_name: DataLog              # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/deprecated_plugins/jointspace/plugin.yaml
+++ b/deprecated_plugins/jointspace/plugin.yaml
@@ -15,7 +15,7 @@ plugin:
     sh_minversion: 1.1             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
-    classname: Jointspace          # class containing the plugin
+    class_name: Jointspace          # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/dlms/__init__.py
+++ b/dlms/__init__.py
@@ -207,7 +207,7 @@ class DLMS(SmartPlugin, conversion.Conversion):
         self.mod_http.register_webif(WebInterface(webif_dir, self), 
                                      self.get_shortname(), 
                                      config, 
-                                     self.get_classname(), self.get_instance_name(),
+                                     self.get_class_name(), self.get_instance_name(),
                                      description='')
                                    
         return True

--- a/dlms/_pv_1_2_5/plugin.yaml
+++ b/dlms/_pv_1_2_5/plugin.yaml
@@ -15,7 +15,7 @@ plugin:
     sh_minversion: 1.2             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
-    classname: DLMS                # class containing the plugin
+    class_name: DLMS                # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/dlms/_pv_1_5_2/__init__.py
+++ b/dlms/_pv_1_5_2/__init__.py
@@ -207,7 +207,7 @@ class DLMS(SmartPlugin, conversion.Conversion):
         self.mod_http.register_webif(WebInterface(webif_dir, self), 
                                      self.get_shortname(), 
                                      config, 
-                                     self.get_classname(), self.get_instance_name(),
+                                     self.get_class_name(), self.get_instance_name(),
                                      description='')
                                    
         return True

--- a/dlms/_pv_1_5_2/plugin.yaml
+++ b/dlms/_pv_1_5_2/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True          # plugin supports multi instance
     restartable: unknown
-    classname: DLMS                # class containing the plugin
+    class_name: DLMS                # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/dlms/plugin.yaml
+++ b/dlms/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True          # plugin supports multi instance
     restartable: unknown
-    classname: DLMS                # class containing the plugin
+    class_name: DLMS                # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/dmx/plugin.yaml
+++ b/dmx/plugin.yaml
@@ -16,7 +16,7 @@ plugin:
 #    sh_minversion: 1.3             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
 #    multi_instance: False
-    classname: DMX                 # class containing the plugin
+    class_name: DMX                 # class containing the plugin
 
 #parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/drexelundweiss/plugin.yaml
+++ b/drexelundweiss/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
     restartable: unknown
-    classname: DuW                 # class containing the plugin
+    class_name: DuW                 # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/easymeter/plugin.yaml
+++ b/easymeter/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_minversion: 1.3             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
 #    multi_instance: False
-    classname: easymeter            # class containing the plugin
+    class_name: easymeter            # class containing the plugin
 
 #parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/ebus/_pv_1_0_1/plugin.yaml
+++ b/ebus/_pv_1_0_1/plugin.yaml
@@ -16,7 +16,7 @@ plugin:
 #    sh_minversion: 1.3             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
 #    multi_instance: False
-    classname: eBus                 # class containing the plugin
+    class_name: eBus                 # class containing the plugin
 
 #parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/ebus/plugin.yaml
+++ b/ebus/plugin.yaml
@@ -18,7 +18,7 @@ plugin:
     sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False
     restartable: unknown
-    classname: eBus                 # class containing the plugin
+    class_name: eBus                 # class containing the plugin
 
 
 parameters:

--- a/ecmd/plugin.yaml
+++ b/ecmd/plugin.yaml
@@ -16,7 +16,7 @@ plugin:
 #    sh_minversion: 1.3             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
 #    multi_instance: False
-    classname: ECMD                 # class containing the plugin
+    class_name: ECMD                 # class containing the plugin
 
 #parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/elro/plugin.yaml
+++ b/elro/plugin.yaml
@@ -16,7 +16,7 @@ plugin:
 #    sh_minversion: 1.3             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
 #    multi_instance: False
-    classname: Elro                 # class containing the plugin
+    class_name: Elro                 # class containing the plugin
 
 #parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/enigma2/plugin.yaml
+++ b/enigma2/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True           # plugin supports multi instance
     restartable: unknown
-    classname: Enigma2             # class containing the plugin
+    class_name: Enigma2             # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/enocean/__init__.py
+++ b/enocean/__init__.py
@@ -783,7 +783,7 @@ class EnOcean(SmartPlugin):
         self.mod_http.register_webif(WebInterface(webif_dir, self),
                                      self.get_shortname(),
                                      config,
-                                     self.get_classname(), self.get_instance_name(),
+                                     self.get_class_name(), self.get_instance_name(),
                                      description='')
 
         return True

--- a/enocean/plugin.yaml
+++ b/enocean/plugin.yaml
@@ -20,7 +20,7 @@ plugin:
     sh_minversion: 1.3             # minimum shNG version to use this plugin
     #sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
-    classname: EnOcean             # class containing the plugin
+    class_name: EnOcean             # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/eta_pu/plugin.yaml
+++ b/eta_pu/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
     restartable: unknown
-    classname: ETA_PU              # class containing the plugin
+    class_name: ETA_PU              # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/gpio/__init__.py
+++ b/gpio/__init__.py
@@ -196,7 +196,7 @@ class Raspi_GPIO(SmartPlugin):
         self.mod_http.register_webif(WebInterface(webif_dir, self),
                                      self.get_shortname(),
                                      config,
-                                     self.get_classname(), self.get_instance_name(),
+                                     self.get_class_name(), self.get_instance_name(),
                                      description='')
 
         return True

--- a/gpio/plugin.yaml
+++ b/gpio/plugin.yaml
@@ -34,7 +34,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
     restartable: unknown
-    classname: Raspi_GPIO          # class containing the plugin
+    class_name: Raspi_GPIO          # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/harmony/plugin.yaml
+++ b/harmony/plugin.yaml
@@ -15,7 +15,7 @@ plugin:
     version: 1.4.1                 # Plugin version
     sh_minversion: 1.4             # minimum shNG version to use this plugin
     multi_instance: False          # plugin supports multi instance
-    classname: Harmony             # class containing the plugin
+    class_name: Harmony             # class containing the plugin
 
 parameters:
   harmony_ip:

--- a/helios/plugin.yaml
+++ b/helios/plugin.yaml
@@ -13,7 +13,7 @@ plugin:
     sh_minversion: 1.1             # minimum shNG version to use this plugin
     multi_instance:  False         # plugin supports multi instance
     restartable: unknown
-    classname: 'Helios'            # class containing the plugin
+    class_name: 'Helios'            # class containing the plugin
 
 parameters:                        # Definition of parameters to be configured in etc/plugin.yaml
     tty:

--- a/homematic/__init__.py
+++ b/homematic/__init__.py
@@ -386,7 +386,7 @@ class Homematic(SmartPlugin):
         self.mod_http.register_webif(WebInterface(webif_dir, self), 
                                      self.get_shortname(), 
                                      config, 
-                                     self.get_classname(), self.get_instance_name(),
+                                     self.get_class_name(), self.get_instance_name(),
                                      description='')
         return True
 

--- a/homematic/plugin.yaml
+++ b/homematic/plugin.yaml
@@ -19,7 +19,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True
     restartable: unknown
-    classname: Homematic            # class containing the plugin
+    class_name: Homematic            # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/hue/_pv_1_1_83/plugin.yaml
+++ b/hue/_pv_1_1_83/plugin.yaml
@@ -16,7 +16,7 @@ plugin:
 #    sh_minversion: 1.3             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
 #    multi_instance: False
-    classname: HUE                  # class containing the plugin
+    class_name: HUE                  # class containing the plugin
 
 #parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/hue/plugin.yaml
+++ b/hue/plugin.yaml
@@ -16,7 +16,7 @@ plugin:
     sh_minversion: 1.3c            # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False
-    classname: HUE                  # class containing the plugin
+    class_name: HUE                  # class containing the plugin
 
 parameters:
 # Definition of parameters to be configured in etc/plugin.yaml

--- a/iaqstick/plugin.yaml
+++ b/iaqstick/plugin.yaml
@@ -16,7 +16,7 @@ plugin:
 #    sh_minversion: 1.3             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
 #    multi_instance: False
-    classname: iAQ_Stick            # class containing the plugin
+    class_name: iAQ_Stick            # class containing the plugin
 
 #parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/ical/plugin.yaml
+++ b/ical/plugin.yaml
@@ -24,7 +24,7 @@ plugin:
     sh_minversion: 1.5             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
-    classname: iCal                # class containing the plugin
+    class_name: iCal                # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/indego/__init__.py
+++ b/indego/__init__.py
@@ -774,7 +774,7 @@ class Indego(SmartPlugin):
         self.mod_http.register_webif(WebInterface(webif_dir, self),
                                      self.get_shortname(),
                                      config,
-                                     self.get_classname(), self.get_instance_name(),
+                                     self.get_class_name(), self.get_instance_name(),
                                      description='')
 
         return True

--- a/indego/plugin.yaml
+++ b/indego/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False           # plugin supports multi instance
     restartable: yes
-    classname: Indego         # class containing the plugin
+    class_name: Indego         # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/influxdata/plugin.yaml
+++ b/influxdata/plugin.yaml
@@ -16,7 +16,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
     restartable: unknown
-    classname: InfluxData          # class containing the plugin
+    class_name: InfluxData          # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/influxdb/plugin.yaml
+++ b/influxdb/plugin.yaml
@@ -16,7 +16,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
     restartable: unknown
-    classname: InfluxDB            # class containing the plugin
+    class_name: InfluxDB            # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/intercom_2n/plugin.yaml
+++ b/intercom_2n/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
     restartable: unknown
-    classname: Intercom2n          # class containing the plugin
+    class_name: Intercom2n          # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/join/plugin.yaml
+++ b/join/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
     restartable: unknown
-    classname: Join                # class containing the plugin
+    class_name: Join                # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/jsonread/plugin.yaml
+++ b/jsonread/plugin.yaml
@@ -15,7 +15,7 @@ plugin:
     sh_minversion: 1.4             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True          # plugin supports multi instance
-    classname: JSONREAD             # class containing the plugin
+    class_name: JSONREAD             # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/jvcproj/plugin.yaml
+++ b/jvcproj/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
     restartable: unknown
-    classname: JVC_DILA_Control    # class containing the plugin
+    class_name: JVC_DILA_Control    # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/kathrein/plugin.yaml
+++ b/kathrein/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_minversion: 1.3             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
 #    multi_instance: False
-    classname: Kathrein            # class containing the plugin
+    class_name: Kathrein            # class containing the plugin
 
 #parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/knx/1_6_beta/__init__.py
+++ b/knx/1_6_beta/__init__.py
@@ -610,7 +610,7 @@ class KNX(SmartPlugin):
         self.mod_http.register_webif(WebInterface(webif_dir, self), 
                                      self.get_shortname(), 
                                      config, 
-                                     self.get_classname(), self.get_instance_name(),
+                                     self.get_class_name(), self.get_instance_name(),
                                      description='')
                                    
         return True

--- a/knx/__init__.py
+++ b/knx/__init__.py
@@ -618,7 +618,7 @@ class KNX(lib.connection.Client,SmartPlugin):
         self.mod_http.register_webif(WebInterface(webif_dir, self),
                                      self.get_shortname(),
                                      config,
-                                     self.get_classname(), self.get_instance_name(),
+                                     self.get_class_name(), self.get_instance_name(),
                                      description='')
 
         return True

--- a/knx/plugin.yaml
+++ b/knx/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True           # plugin supports multi instance
     restartable: unknown
-    classname: KNX                 # class containing the plugin
+    class_name: KNX                 # class containing the plugin
     attribute_prefix: knx          # prefix of the item-attributes, so attributes have to start with 'knx_'
 
 parameters:

--- a/knx/pv_1_3_4/plugin.yaml
+++ b/knx/pv_1_3_4/plugin.yaml
@@ -14,7 +14,7 @@ plugin:
     sh_minversion: 1.3             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True           # plugin supports multi instance
-    classname: KNX                 # class containing the plugin
+    class_name: KNX                 # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/kodi/plugin.yaml
+++ b/kodi/plugin.yaml
@@ -21,7 +21,7 @@ plugin:
     sh_minversion: 1.4            # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True
-    classname: Kodi                # class containing the plugin
+    class_name: Kodi                # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/kostal/plugin.yaml
+++ b/kostal/plugin.yaml
@@ -32,7 +32,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True           # plugin supports multi instance
     restartable: unknown
-    classname: Kostal              # class containing the plugin
+    class_name: Kostal              # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/lirc/plugin.yaml
+++ b/lirc/plugin.yaml
@@ -16,7 +16,7 @@ plugin:
     sh_minversion: 1.3             # minimum shNG version to use this plugin
 #    sh_maxversion:                # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True           # plugin supports multi instance
-    classname: LIRC                # class containing the plugin
+    class_name: LIRC                # class containing the plugin
 
 
 parameters:

--- a/logo/plugin.yaml
+++ b/logo/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True           # plugin supports multi instance
     restartable: unknown
-    classname: LOGO                # class containing the plugin
+    class_name: LOGO                # class containing the plugin
 
 parameters:
 # Definition of parameters to be configured in etc/plugin.yaml

--- a/luxtronic2/plugin.yaml
+++ b/luxtronic2/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False
     restartable: unknown
-    classname: LuxBase              # class containing the plugin
+    class_name: LuxBase              # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/mail/plugin.yaml
+++ b/mail/plugin.yaml
@@ -16,8 +16,8 @@ plugin:
     sh_minversion: 1.3             # minimum shNG version to use this plugin
     sh_maxversion: 1.6.9           # To be retired with SmartHomeNG v1.7
     multi_instance: False          # plugin supports multi instance
-    classname: SMTP                # class containing the plugin
-#    classname: IMAP                # class containing the plugin
+    class_name: SMTP                # class containing the plugin
+#    class_name: IMAP                # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/mailrcv/plugin.yaml
+++ b/mailrcv/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True           # plugin supports multi instance
     restartable: unknown
-    classname: IMAP                # class containing the plugin
+    class_name: IMAP                # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/mailsend/plugin.yaml
+++ b/mailsend/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True           # plugin supports multi instance
     restartable: unknown
-    classname: SMTP                # class containing the plugin
+    class_name: SMTP                # class containing the plugin
 
 
 parameters:

--- a/memlog/plugin.yaml
+++ b/memlog/plugin.yaml
@@ -16,7 +16,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False
     restartable: unknown
-    classname: MemLog               # class containing the plugin
+    class_name: MemLog               # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/miflora/plugin.yaml
+++ b/miflora/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True           # plugin supports multi instance
     restartable: unknown
-    classname: Miflora              # class containing the plugin
+    class_name: Miflora              # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/milight/plugin.yaml
+++ b/milight/plugin.yaml
@@ -16,7 +16,7 @@ plugin:
 #    sh_minversion: 1.3             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
 #    multi_instance: False
-    classname: milight              # class containing the plugin
+    class_name: milight              # class containing the plugin
 
 #parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/mlgw/plugin.yaml
+++ b/mlgw/plugin.yaml
@@ -16,7 +16,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
     restartable: False
-    classname: Mlgw                # class containing the plugin
+    class_name: Mlgw                # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/mpd/plugin.yaml
+++ b/mpd/plugin.yaml
@@ -16,7 +16,7 @@ plugin:
     sh_minversion: 1.3             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True
-    classname: MPD                 # class containing the plugin
+    class_name: MPD                 # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/mqtt/__init__.py
+++ b/mqtt/__init__.py
@@ -336,7 +336,7 @@ class Mqtt(SmartPlugin):
         self.mod_http.register_webif(WebInterface(webif_dir, self),
                                      self.get_shortname(),
                                      config,
-                                     self.get_classname(), self.get_instance_name(),
+                                     self.get_class_name(), self.get_instance_name(),
                                      description='')
 
         return True

--- a/mqtt/_pv_1_0_1/plugin.yaml
+++ b/mqtt/_pv_1_0_1/plugin.yaml
@@ -15,7 +15,7 @@ plugin:
     sh_minversion: 1.3             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True
-    classname: Mqtt                # class containing the plugin
+    class_name: Mqtt                # class containing the plugin
 
 #parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/mqtt/plugin.yaml
+++ b/mqtt/plugin.yaml
@@ -58,7 +58,7 @@ plugin:
     sh_minversion: 1.4             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True           # plugin supports multi instance
-    classname: Mqtt                # class containing the plugin
+    class_name: Mqtt                # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/mvg_live/plugin.yaml
+++ b/mvg_live/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
     restartable: unknown
-    classname: MVG_Live            # class containing the plugin
+    class_name: MVG_Live            # class containing the plugin
 
 parameters: NONE
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/neato/plugin.yaml
+++ b/neato/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False           # plugin supports multi instance
     restartable: unknown
-    classname: Neato         # class containing the plugin
+    class_name: Neato         # class containing the plugin
 
 parameters:
     account_email:

--- a/netio230b/plugin.yaml
+++ b/netio230b/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_minversion: 1.3             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
 #    multi_instance: False
-    classname: NetIO230B           # class containing the plugin
+    class_name: NetIO230B           # class containing the plugin
 
 #parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/network/plugin.yaml
+++ b/network/plugin.yaml
@@ -16,7 +16,7 @@ plugin:
 #    sh_maxversion:                # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
     restartable: unknown
-    classname: Network             # class containing the plugin
+    class_name: Network             # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/nma/plugin.yaml
+++ b/nma/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_minversion: 1.3             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
 #    multi_instance: False
-    classname: NMA                 # class containing the plugin
+    class_name: NMA                 # class containing the plugin
 
 #parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/nuki/__init__.py
+++ b/nuki/__init__.py
@@ -364,7 +364,7 @@ class Nuki(SmartPlugin):
         self.mod_http.register_webif(WebInterface(webif_dir, self),
                                      self.get_shortname(),
                                      config,
-                                     self.get_classname(), self.get_instance_name(),
+                                     self.get_class_name(), self.get_instance_name(),
                                      description='')
 
         return True

--- a/nuki/plugin.yaml
+++ b/nuki/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
     restartable: unknown
-    classname: Nuki                # class containing the plugin
+    class_name: Nuki                # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/nut/plugin.yaml
+++ b/nut/plugin.yaml
@@ -26,7 +26,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True           # plugin supports multi instance
     restartable: unknown
-    classname: NUT                 # class containing the plugin
+    class_name: NUT                 # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/odlinfo/plugin.yaml
+++ b/odlinfo/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
     restartable: unknown
-    classname: ODLInfo             # class containing the plugin
+    class_name: ODLInfo             # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/onewire/plugin.yaml
+++ b/onewire/plugin.yaml
@@ -13,7 +13,7 @@ plugin:
     sh_minversion: 1.3             # minimum shNG version to use this plugin
     multi_instance: False
     restartable: unknown
-    classname: OneWire              # class containing the plugin
+    class_name: OneWire              # class containing the plugin
 
 parameters:
     host:

--- a/openenergymonitor/plugin.yaml
+++ b/openenergymonitor/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_minversion: 1.3             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
 #    multi_instance: False
-    classname: OpenEnergyMonitor   # class containing the plugin
+    class_name: OpenEnergyMonitor   # class containing the plugin
 
 #parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/openweathermap/__init__.py
+++ b/openweathermap/__init__.py
@@ -368,7 +368,7 @@ class OpenWeatherMap(SmartPlugin):
         self.mod_http.register_webif(WebInterface(webif_dir, self),
                                      self.get_shortname(),
                                      config,
-                                     self.get_classname(), self.get_instance_name(),
+                                     self.get_class_name(), self.get_instance_name(),
                                      description='')
 
         return True

--- a/openweathermap/plugin.yaml
+++ b/openweathermap/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:               # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True          # plugin supports multi instance
     restartable: unknown
-    classname: OpenWeatherMap     # class containing the plugin
+    class_name: OpenWeatherMap     # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/operationlog/plugin.yaml
+++ b/operationlog/plugin.yaml
@@ -16,7 +16,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
     restartable: unknown
-    classname: OperationLog        # class containing the plugin
+    class_name: OperationLog        # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/plex/plugin.yaml
+++ b/plex/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
     restartable: unknown
-    classname: Plex                # class containing the plugin
+    class_name: Plex                # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/pluggit/plugin.yaml
+++ b/pluggit/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
     restartable: unknown
-    classname: Pluggit             # class containing the plugin
+    class_name: Pluggit             # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/prowl/plugin.yaml
+++ b/prowl/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True           # plugin supports multi instance
     restartable: unknown
-    classname: Prowl               # class containing the plugin
+    class_name: Prowl               # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/pushbullet/plugin.yaml
+++ b/pushbullet/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
     restartable: unknown
-    classname: Pushbullet          # class containing the plugin
+    class_name: Pushbullet          # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/pushover/_pv_1_3_1/plugin.yaml
+++ b/pushover/_pv_1_3_1/plugin.yaml
@@ -10,7 +10,7 @@ plugin:
     version: 1.3.1.0               # Plugin version
     sh_minversion: 1.2             # minimum shNG version to use this plugin
     multi_instance: False          # plugin supports multi instance
-    classname: Pushover            # class containing the plugin
+    class_name: Pushover            # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/pushover/plugin.yaml
+++ b/pushover/plugin.yaml
@@ -12,7 +12,7 @@ plugin:
     version: 1.6.1.0               # Plugin version
     sh_minversion: 1.5             # minimum shNG version to use this plugin
     multi_instance: True           # plugin supports multi instance
-    classname: Pushover            # class containing the plugin
+    class_name: Pushover            # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/raumfeld/plugin.yaml
+++ b/raumfeld/plugin.yaml
@@ -16,7 +16,7 @@ plugin:
 #    sh_minversion: 1.3             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
 #    multi_instance: False
-    classname: Raumfeld            # class containing the plugin
+    class_name: Raumfeld            # class containing the plugin
 
 #parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/rcswitch/plugin.yaml
+++ b/rcswitch/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False         # plugin supports multi instance
     restartable: unknown
-    classname: RCswitch           # class containing the plugin
+    class_name: RCswitch           # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/roomba/plugin.yaml
+++ b/roomba/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_minversion: 1.3             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
 #    multi_instance: False
-    classname: Roomba              # class containing the plugin
+    class_name: Roomba              # class containing the plugin
 
 #parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/roomba_980/plugin.yaml
+++ b/roomba_980/plugin.yaml
@@ -18,7 +18,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False
     restartable: unknown
-    classname: ROOMBA_980              # class containing the plugin
+    class_name: ROOMBA_980              # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/rrd/plugin.yaml
+++ b/rrd/plugin.yaml
@@ -16,7 +16,7 @@ plugin:
 #    sh_minversion: 1.3             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
 #    multi_instance: False
-    classname: RRD                 # class containing the plugin
+    class_name: RRD                 # class containing the plugin
 
 #parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/rtr/plugin.yaml
+++ b/rtr/plugin.yaml
@@ -11,7 +11,7 @@ plugin:
     version: 1.2.3                 # Plugin version
     sh_minversion: 1.2             # minimum shNG version to use this plugin
     multi_instance: False          # plugin supports multi instance
-    classname: RTR                 # class containing the plugin
+    class_name: RTR                 # class containing the plugin
 
 parameters:
     default_Kp:

--- a/russound/plugin.yaml
+++ b/russound/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_minversion: 1.3             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
 #    multi_instance: False
-    classname: Russound            # class containing the plugin
+    class_name: Russound            # class containing the plugin
 
 #parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/simulation/__init__.py
+++ b/simulation/__init__.py
@@ -410,7 +410,7 @@ class Simulation(SmartPlugin):
         self.mod_http.register_webif(WebInterface(webif_dir, self),
                                      self.get_shortname(),
                                      config,
-                                     self.get_classname(), self.get_instance_name(),
+                                     self.get_class_name(), self.get_instance_name(),
                                      description='')
 
         return True

--- a/simulation/plugin.yaml
+++ b/simulation/plugin.yaml
@@ -16,7 +16,7 @@ plugin:
 #    sh_maxversion:                # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
     restartable: unknown
-    classname: Simulation          # class containing the plugin
+    class_name: Simulation          # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/slack/plugin.yaml
+++ b/slack/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:               # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True          # plugin supports multi instance
     restartable: True             # restartable: yes
-    classname: Slack              # class containing the plugin
+    class_name: Slack              # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/sma/plugin.yaml
+++ b/sma/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
     restartable: unknown
-    classname: SMA                 # class containing the plugin
+    class_name: SMA                 # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/sma_em/__init__.py
+++ b/sma_em/__init__.py
@@ -379,7 +379,7 @@ class SMA_EM(SmartPlugin):
         self.mod_http.register_webif(WebInterface(webif_dir, self),
                                      self.get_shortname(),
                                      config,
-                                     self.get_classname(), self.get_instance_name(),
+                                     self.get_class_name(), self.get_instance_name(),
                                      description='')
 
         return True

--- a/sma_em/plugin.yaml
+++ b/sma_em/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
     restartable: unknown
-    classname: SMA_EM              # class containing the plugin
+    class_name: SMA_EM              # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/smarttv/plugin.yaml
+++ b/smarttv/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True           # plugin supports multi instance
     restartable: unknown
-    classname: SmartTV             # class containing the plugin
+    class_name: SmartTV             # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/smawb/plugin.yaml
+++ b/smawb/plugin.yaml
@@ -16,7 +16,7 @@ plugin:
 #    sh_minversion: 1.3             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
 #    multi_instance: False
-    classname: SMAWB               # class containing the plugin
+    class_name: SMAWB               # class containing the plugin
 
 #parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/sml/plugin.yaml
+++ b/sml/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True           # plugin supports multi instance
     restartable: unknown
-    classname: Sml                 # class containing the plugin
+    class_name: Sml                 # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/smlx/plugin.yaml
+++ b/smlx/plugin.yaml
@@ -15,7 +15,7 @@ plugin:
     sh_minversion: 1.4.2           # minimum shNG version to use this plugin
 #    sh_maxversion:                # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True           # plugin supports multi instance
-    classname: Sml                 # class containing the plugin
+    class_name: Sml                 # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/snap7_logo/__init__.py
+++ b/snap7_logo/__init__.py
@@ -528,7 +528,7 @@ class snap7logo(SmartPlugin):
         self.mod_http.register_webif(WebInterface(webif_dir, self), 
                                      self.get_shortname(), 
                                      config, 
-                                     self.get_classname(), self.get_instance_name(),
+                                     self.get_class_name(), self.get_instance_name(),
                                      description='')
                                    
         return True

--- a/snap7_logo/plugin.yaml
+++ b/snap7_logo/plugin.yaml
@@ -15,7 +15,7 @@ plugin:
     sh_minversion: 1.5             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True           # plugin supports multi instance
-    classname: snap7_logo          # class containing the plugin
+    class_name: snap7_logo          # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/snom/plugin.yaml
+++ b/snom/plugin.yaml
@@ -16,7 +16,7 @@ plugin:
 #    sh_minversion: 1.3             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
 #    multi_instance: False
-    classname: Snom                # class containing the plugin
+    class_name: Snom                # class containing the plugin
 
 #parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/solarlog/plugin.yaml
+++ b/solarlog/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_minversion: 1.3             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
 #    multi_instance: False
-    classname: SolarLog            # class containing the plugin
+    class_name: SolarLog            # class containing the plugin
 
 #parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/sonos/plugin.yaml
+++ b/sonos/plugin.yaml
@@ -14,7 +14,7 @@ plugin:
   version: 1.4.9                 # Plugin version
   sh_minversion: 1.5.1           # minimum shNG version to use this plugin
   multi_instance: False          # plugin supports multi instance
-  classname: Sonos               # class containing the plugin
+  class_name: Sonos               # class containing the plugin
 
 parameters:
   tts:

--- a/speech/plugin.yaml
+++ b/speech/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_minversion: 1.3             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
 #    multi_instance: False
-    classname: Speech_Parser       # class containing the plugin
+    class_name: Speech_Parser       # class containing the plugin
 
 #parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/sqlite/plugin.yaml
+++ b/sqlite/plugin.yaml
@@ -16,7 +16,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
     restartable: unknown
-    classname: SQL                 # class containing the plugin
+    class_name: SQL                 # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/sqlite_visu2_8/plugin.yaml
+++ b/sqlite_visu2_8/plugin.yaml
@@ -16,7 +16,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
     restartable: unknown
-    classname: SQL                 # class containing the plugin
+    class_name: SQL                 # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/squeezebox/plugin.yaml
+++ b/squeezebox/plugin.yaml
@@ -35,7 +35,7 @@ plugin:
     sh_minversion: 1.3             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
-    classname: Squeezebox          # class containing the plugin
+    class_name: Squeezebox          # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/stateengine/__init__.py
+++ b/stateengine/__init__.py
@@ -222,7 +222,7 @@ class StateEngine(SmartPlugin):
         self.mod_http.register_webif(WebInterface(webif_dir, self),
                                      self.get_shortname(),
                                      config,
-                                     self.get_classname(), self.get_instance_name(),
+                                     self.get_class_name(), self.get_instance_name(),
                                      description='')
 
         return True

--- a/stateengine/_pv_1_4_2/__init__.py
+++ b/stateengine/_pv_1_4_2/__init__.py
@@ -178,7 +178,7 @@ class StateEngine(SmartPlugin):
         self.mod_http.register_webif(WebInterface(webif_dir, self),
                                      self.get_shortname(),
                                      config,
-                                     self.get_classname(), self.get_instance_name(),
+                                     self.get_class_name(), self.get_instance_name(),
                                      description='')
 
         return True

--- a/stateengine/_pv_1_4_2/plugin.yaml
+++ b/stateengine/_pv_1_4_2/plugin.yaml
@@ -29,7 +29,7 @@ plugin:
     version: 1.4.2
     sh_minversion: 1.5d
     multi_instance: False
-    classname: StateEngine
+    class_name: StateEngine
     restartable: unknown
     attribute_prefix: se
 

--- a/stateengine/plugin.yaml
+++ b/stateengine/plugin.yaml
@@ -43,7 +43,7 @@ plugin:
     version: 1.6.2
     sh_minversion: 1.6
     multi_instance: False
-    classname: StateEngine
+    class_name: StateEngine
     restartable: unknown
     attribute_prefix: se
 

--- a/systemair/plugin.yaml
+++ b/systemair/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
     restartable: unknown
-    classname: Systemair           # class containing the plugin
+    class_name: Systemair           # class containing the plugin
 
 parameters:
 # Definition of parameters to be configured in etc/plugin.yaml

--- a/tankerkoenig/plugin.yaml
+++ b/tankerkoenig/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
     restartable: unknown
-    classname: TankerKoenig        # class containing the plugin
+    class_name: TankerKoenig        # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/telegram/__init__.py
+++ b/telegram/__init__.py
@@ -571,7 +571,7 @@ class Telegram(SmartPlugin):
         self.mod_http.register_webif(WebInterface(webif_dir, self), 
                                      self.get_shortname(), 
                                      config, 
-                                     self.get_classname(), self.get_instance_name(),
+                                     self.get_class_name(), self.get_instance_name(),
                                      description='')
                                    
         return True

--- a/telegram/_pv_1_1_3/plugin.yaml
+++ b/telegram/_pv_1_1_3/plugin.yaml
@@ -15,7 +15,7 @@ plugin:
     sh_minversion: 1.1             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
-    classname: Telegram            # class containing the plugin
+    class_name: Telegram            # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/telegram/_pv_1_5_0/__init__.py
+++ b/telegram/_pv_1_5_0/__init__.py
@@ -436,7 +436,7 @@ class Telegram(SmartPlugin):
         self.mod_http.register_webif(WebInterface(webif_dir, self), 
                                      self.get_shortname(), 
                                      config, 
-                                     self.get_classname(), self.get_instance_name(),
+                                     self.get_class_name(), self.get_instance_name(),
                                      description='')
                                    
         return True

--- a/telegram/_pv_1_5_0/plugin.yaml
+++ b/telegram/_pv_1_5_0/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
     restartable: True
-    classname: Telegram            # class containing the plugin
+    class_name: Telegram            # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/telegram/plugin.yaml
+++ b/telegram/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True            # plugin supports multi instance
     restartable: True
-    classname: Telegram             # class containing the plugin
+    class_name: Telegram             # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/tellstick/plugin.yaml
+++ b/tellstick/plugin.yaml
@@ -16,7 +16,7 @@ plugin:
 #    sh_minversion: 1.3             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
 #    multi_instance: False
-    classname: Tellstick           # class containing the plugin
+    class_name: Tellstick           # class containing the plugin
 
 #parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/thz/__init__.py
+++ b/thz/__init__.py
@@ -364,7 +364,7 @@ class THZ(SmartPlugin):
         self.mod_http.register_webif(WebInterface(webif_dir, self),
                                      self.get_shortname(),
                                      config,
-                                     self.get_classname(), self.get_instance_name(),
+                                     self.get_class_name(), self.get_instance_name(),
                                      description='')
 
         return True

--- a/thz/plugin.yaml
+++ b/thz/plugin.yaml
@@ -13,7 +13,7 @@ plugin:
     sh_minversion: 1.4
     multi_instance: False
     restartable: unknown
-    classname: THZ
+    class_name: THZ
 
 parameters:
     serial_port:

--- a/traffic/plugin.yaml
+++ b/traffic/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
     restartable: unknown
-    classname: Traffic             # class containing the plugin
+    class_name: Traffic             # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/trovis557x/__init__.py
+++ b/trovis557x/__init__.py
@@ -139,7 +139,7 @@ class trovis557x(SmartPlugin):
         self.mod_http.register_webif(WebInterface(webif_dir, self),
                                      self.get_shortname(),
                                      config,
-                                     self.get_classname(), self.get_instance_name(),
+                                     self.get_class_name(), self.get_instance_name(),
                                      description='')
 
         return True

--- a/trovis557x/plugin.yaml
+++ b/trovis557x/plugin.yaml
@@ -18,7 +18,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False
     restartable: unknown
-    classname: trovis557x
+    class_name: trovis557x
 
 
 item_attributes:

--- a/unifi/__init__.py
+++ b/unifi/__init__.py
@@ -691,7 +691,7 @@ class UniFiControllerClient(SmartPlugin):
         self.mod_http.register_webif(WebInterface(webif_dir, self),
                                      self.get_shortname(),
                                      config,
-                                     self.get_classname(), self.get_instance_name(),
+                                     self.get_class_name(), self.get_instance_name(),
                                      description='')
 
         return True

--- a/unifi/plugin.yaml
+++ b/unifi/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False           # plugin supports multi instance
     restartable: True
-    classname: UniFiControllerClient         # class containing the plugin
+    class_name: UniFiControllerClient         # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml (enter 'parameters: NONE', if section should be empty)

--- a/uzsu/__init__.py
+++ b/uzsu/__init__.py
@@ -937,7 +937,7 @@ class UZSU(SmartPlugin):
         self.mod_http.register_webif(WebInterface(webif_dir, self),
                                      self.get_shortname(),
                                      config,
-                                     self.get_classname(), self.get_instance_name(),
+                                     self.get_class_name(), self.get_instance_name(),
                                      description='')
 
         return True

--- a/uzsu/plugin.yaml
+++ b/uzsu/plugin.yaml
@@ -52,7 +52,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
     restartable: unknown
-    classname: UZSU                # class containing the plugin
+    class_name: UZSU                # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/visu_smartvisu/__init__.py
+++ b/visu_smartvisu/__init__.py
@@ -596,35 +596,35 @@ class SmartVisuInstallWidgets:
         return
         
 
-    def create_htmlinclude(self, filename, classname, root_contents, iln_html):
+    def create_htmlinclude(self, filename, class_name, root_contents, iln_html):
         insertln = root_contents.index(iln_html) +1
         # Insert widget statements to root_contents
         if insertln != 0:
             self.logger.debug( "create_htmlinclude: Inserting in root.html at line {0} after '{1}'".format(insertln, iln_html) )
-            twig_statement = '\t{% import "' + self.shwdgdir + '/' + filename + '" as ' + classname + ' %}'
+            twig_statement = '\t{% import "' + self.shwdgdir + '/' + filename + '" as ' + class_name + ' %}'
             root_contents.insert(insertln, twig_statement+'\n')
 
 
-    def create_jsinclude(self, filename, classname, root_contents, iln_js):
+    def create_jsinclude(self, filename, class_name, root_contents, iln_js):
         insertln = root_contents.index(iln_js)
         # Insert widget statements to root_contents
         if insertln > -1:
             self.logger.debug( "create_jsinclude: Inserting in root.html at line {0} before '{1}'".format(insertln, iln_js) )
             twig_statement1 = "\t{% if isfile('widgets/sh_widgets/" + filename + "') %}"
-            twig_statement2 = '\t\t<script type="text/javascript" src="widgets/sh_widgets/widget_' + classname + '.js"></script>{% endif %}'
+            twig_statement2 = '\t\t<script type="text/javascript" src="widgets/sh_widgets/widget_' + class_name + '.js"></script>{% endif %}'
             self.logger.debug('create_jsinclude: {0}'.format(twig_statement1))
             self.logger.debug('create_jsinclude: {0}'.format(twig_statement2))
             root_contents.insert(insertln, twig_statement2+'\n')
             root_contents.insert(insertln, twig_statement1+'\n')
 
 
-    def create_cssinclude(self, filename, classname, root_contents, iln_css):
+    def create_cssinclude(self, filename, class_name, root_contents, iln_css):
         insertln = root_contents.index(iln_css)
         # Insert widget statements to root_contents
         if insertln > -1:
             self.logger.debug( "create_jsinclude: Inserting in root.html at line {0} before '{1}'".format(insertln, iln_css) )
             twig_statement1 = "\t{% if isfile('widgets/sh_widgets/" + filename + "') %}"
-            twig_statement2 = '\t\t<link rel="stylesheet" type="text/css" href="widgets/sh_widgets/widget_' + classname + '.css" />{% endif %}'
+            twig_statement2 = '\t\t<link rel="stylesheet" type="text/css" href="widgets/sh_widgets/widget_' + class_name + '.css" />{% endif %}'
             self.logger.debug('create_cssinclude: {0}'.format(twig_statement1))
             self.logger.debug('create_cssinclude: {0}'.format(twig_statement2))
             root_contents.insert(insertln, twig_statement2+'\n')

--- a/visu_smartvisu/_pv_1_3_3/__init__.py
+++ b/visu_smartvisu/_pv_1_3_3/__init__.py
@@ -512,35 +512,35 @@ class SmartVisuInstallWidgets:
         return
         
 
-    def create_htmlinclude(self, filename, classname, root_contents, iln_html):
+    def create_htmlinclude(self, filename, class_name, root_contents, iln_html):
         insertln = root_contents.index(iln_html) +1
         # Insert widget statements to root_contents
         if insertln != 0:
             self.logger.debug( "create_htmlinclude: Inserting in root.html at line {0} after '{1}'".format(insertln, iln_html) )
-            twig_statement = '\t{% import "' + self.shwdgdir + '/' + filename + '" as ' + classname + ' %}'
+            twig_statement = '\t{% import "' + self.shwdgdir + '/' + filename + '" as ' + class_name + ' %}'
             root_contents.insert(insertln, twig_statement+'\n')
 
 
-    def create_jsinclude(self, filename, classname, root_contents, iln_js):
+    def create_jsinclude(self, filename, class_name, root_contents, iln_js):
         insertln = root_contents.index(iln_js)
         # Insert widget statements to root_contents
         if insertln > -1:
             self.logger.debug( "create_jsinclude: Inserting in root.html at line {0} before '{1}'".format(insertln, iln_js) )
             twig_statement1 = "\t{% if isfile('widgets/sh_widgets/" + filename + "') %}"
-            twig_statement2 = '\t\t<script type="text/javascript" src="widgets/sh_widgets/widget_' + classname + '.js"></script>{% endif %}'
+            twig_statement2 = '\t\t<script type="text/javascript" src="widgets/sh_widgets/widget_' + class_name + '.js"></script>{% endif %}'
             self.logger.debug('create_jsinclude: {0}'.format(twig_statement1))
             self.logger.debug('create_jsinclude: {0}'.format(twig_statement2))
             root_contents.insert(insertln, twig_statement2+'\n')
             root_contents.insert(insertln, twig_statement1+'\n')
 
 
-    def create_cssinclude(self, filename, classname, root_contents, iln_css):
+    def create_cssinclude(self, filename, class_name, root_contents, iln_css):
         insertln = root_contents.index(iln_css)
         # Insert widget statements to root_contents
         if insertln > -1:
             self.logger.debug( "create_jsinclude: Inserting in root.html at line {0} before '{1}'".format(insertln, iln_css) )
             twig_statement1 = "\t{% if isfile('widgets/sh_widgets/" + filename + "') %}"
-            twig_statement2 = '\t\t<link rel="stylesheet" type="text/css" href="widgets/sh_widgets/widget_' + classname + '.css" />{% endif %}'
+            twig_statement2 = '\t\t<link rel="stylesheet" type="text/css" href="widgets/sh_widgets/widget_' + class_name + '.css" />{% endif %}'
             self.logger.debug('create_cssinclude: {0}'.format(twig_statement1))
             self.logger.debug('create_cssinclude: {0}'.format(twig_statement2))
             root_contents.insert(insertln, twig_statement2+'\n')

--- a/visu_smartvisu/_pv_1_3_3/plugin.yaml
+++ b/visu_smartvisu/_pv_1_3_3/plugin.yaml
@@ -14,7 +14,7 @@ plugin:
     sh_minversion: 1.3             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
-    classname: SmartVisu           # class containing the plugin
+    class_name: SmartVisu           # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/visu_smartvisu/plugin.yaml
+++ b/visu_smartvisu/plugin.yaml
@@ -16,7 +16,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True           # plugin supports multi instance
     restartable: True
-    classname: SmartVisu           # class containing the plugin
+    class_name: SmartVisu           # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/visu_websocket/__init__.py
+++ b/visu_websocket/__init__.py
@@ -186,7 +186,7 @@ class WebSocket(SmartPlugin):
         self.mod_http.register_webif(WebInterface(webif_dir, self),
                                      self.get_shortname(),
                                      config,
-                                     self.get_classname(), self.get_instance_name(),
+                                     self.get_class_name(), self.get_instance_name(),
                                      description='',
                                      webifname='')
 

--- a/visu_websocket/_pv_1_1_3/plugin.yaml
+++ b/visu_websocket/_pv_1_1_3/plugin.yaml
@@ -14,7 +14,7 @@ plugin:
     sh_minversion: 1.2             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
-    classname: WebSocket           # class containing the plugin
+    class_name: WebSocket           # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/visu_websocket/_pv_1_4_5/__init__.py
+++ b/visu_websocket/_pv_1_4_5/__init__.py
@@ -179,7 +179,7 @@ class WebSocket(SmartPlugin):
         self.mod_http.register_webif(WebInterface(webif_dir, self), 
                                      self.get_shortname(), 
                                      config, 
-                                     self.get_classname(), self.get_instance_name(),
+                                     self.get_class_name(), self.get_instance_name(),
                                      description='',
                                      webifname='')
                                    

--- a/visu_websocket/_pv_1_4_5/plugin.yaml
+++ b/visu_websocket/_pv_1_4_5/plugin.yaml
@@ -16,7 +16,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
     restartable: unknown
-    classname: WebSocket           # class containing the plugin
+    class_name: WebSocket           # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/visu_websocket/plugin.yaml
+++ b/visu_websocket/plugin.yaml
@@ -16,7 +16,7 @@ plugin:
 #    sh_maxversion:               # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False         # plugin supports multi instance
     restartable: unknown
-    classname: WebSocket          # class containing the plugin
+    class_name: WebSocket          # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/volkszaehler/plugin.yaml
+++ b/volkszaehler/plugin.yaml
@@ -18,7 +18,7 @@ plugin:
 #    sh_maxversion:                # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True
     restartable: unknown
-    classname: Volkszaehler        # class containing the plugin
+    class_name: Volkszaehler        # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml (enter 'parameters: NONE', if section should be empty)

--- a/vr100/plugin.yaml
+++ b/vr100/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_minversion: 1.3             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
 #    multi_instance: False
-    classname: VR100               # class containing the plugin
+    class_name: VR100               # class containing the plugin
 
 #parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/webservices/__init__.py
+++ b/webservices/__init__.py
@@ -73,7 +73,7 @@ class WebServices(SmartPlugin):
         self.mod_http.register_service(RESTWebServicesInterface(webif_dir, self),
                                        self.get_shortname(),
                                        config,
-                                       self.get_classname(), self.get_instance_name(),
+                                       self.get_class_name(), self.get_instance_name(),
                                        description='WebService Plugin für SmartHomeNG (REST)',
                                        servicename='rest')
 
@@ -81,7 +81,7 @@ class WebServices(SmartPlugin):
         self.mod_http.register_service(SimpleWebServiceInterface(webif_dir, self),
                                        self.get_shortname(),
                                        config,
-                                       self.get_classname(), self.get_instance_name(),
+                                       self.get_class_name(), self.get_instance_name(),
                                        description='Webservice-Plugin für SmartHomeNG (simple)',
                                        servicename='ws')
 
@@ -89,7 +89,7 @@ class WebServices(SmartPlugin):
         self.mod_http.register_webif(WebInterface(webif_dir, self),
                                      self.get_shortname(),
                                      config,
-                                     self.get_classname(), self.get_instance_name(),
+                                     self.get_class_name(), self.get_instance_name(),
                                      description='Webservice-Plugin für SmartHomeNG (Frontend)')
 
         return True

--- a/webservices/plugin.yaml
+++ b/webservices/plugin.yaml
@@ -18,7 +18,7 @@ plugin:
 #    sh_maxversion:                # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
     restartable: unknown
-    classname: WebServices         # class containing the plugin
+    class_name: WebServices         # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/wettercom/_pv_1_3_1/plugin.yaml
+++ b/wettercom/_pv_1_3_1/plugin.yaml
@@ -15,7 +15,7 @@ plugin:
     sh_minversion: 1.3             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
-    classname: wettercom           # class containing the plugin
+    class_name: wettercom           # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/wettercom/plugin.yaml
+++ b/wettercom/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
     restartable: unknown
-    classname: wettercom           # class containing the plugin
+    class_name: wettercom           # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/withings_health/__init__.py
+++ b/withings_health/__init__.py
@@ -315,7 +315,7 @@ class WithingsHealth(SmartPlugin):
         self.mod_http.register_webif(WebInterface(webif_dir, self),
                                      self.get_shortname(),
                                      config,
-                                     self.get_classname(), self.get_instance_name(),
+                                     self.get_class_name(), self.get_instance_name(),
                                      description='')
 
         return True

--- a/withings_health/plugin.yaml
+++ b/withings_health/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True           # plugin supports multi instance
     restartable: unknown
-    classname: NokiaHealth         # class containing the plugin
+    class_name: NokiaHealth         # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/wol/plugin.yaml
+++ b/wol/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True           # plugin supports multi instance
     restartable: unknown
-    classname: WakeOnLan           # class containing the plugin
+    class_name: WakeOnLan           # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/wunderground/__init__.py
+++ b/wunderground/__init__.py
@@ -345,7 +345,7 @@ class Wunderground(SmartPlugin):
         self.mod_http.register_webif(WebInterface(webif_dir, self), 
                                      self.get_shortname(), 
                                      config, 
-                                     self.get_classname(), self.get_instance_name(),
+                                     self.get_class_name(), self.get_instance_name(),
                                      description='')
                                    
         return True

--- a/wunderground/plugin.yaml
+++ b/wunderground/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True           # plugin supports multi instance
     restartable: unknown
-    classname: Wunderground        # class containing the plugin
+    class_name: Wunderground        # class containing the plugin
 
 
 parameters:

--- a/xbmc/plugin.yaml
+++ b/xbmc/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_minversion: 1.3             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
 #    multi_instance: False
-    classname: XBMC                # class containing the plugin
+    class_name: XBMC                # class containing the plugin
 
 #parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/xmpp/plugin.yaml
+++ b/xmpp/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False
     restartable: unknown
-    classname: XMPP                # class containing the plugin
+    class_name: XMPP                # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/yamaha/plugin.yaml
+++ b/yamaha/plugin.yaml
@@ -16,7 +16,7 @@ plugin:
     sh_minversion: 1.1             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
-    classname: Yamaha              # class containing the plugin
+    class_name: Yamaha              # class containing the plugin
 
 parameters: NONE
     # Definition of parameters to be configured in etc/plugin.yaml

--- a/zwave/plugin.yaml
+++ b/zwave/plugin.yaml
@@ -15,7 +15,7 @@ plugin:
     sh_minversion: 1.3             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
-    classname: ZWave               # class containing the plugin
+    class_name: ZWave               # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml


### PR DESCRIPTION
class_name should be written always the same - leads to confusion if it is sometimes spelled classname while meaning the same thing. Best example: https://knx-user-forum.de/forum/supportforen/smarthome-py/1422178-class_name-und-classname-konsolidierung-der-schreibweisen - this has to be merged together with the changes in the smarthome repo!