### PR TITLE
knx: added hostname support

### DIFF
--- a/knx/README.md
+++ b/knx/README.md
@@ -27,7 +27,7 @@ knx:
 
 #### Attributes
 
-* `host` : eibd or knxd hostname (default: 127.0.0.1)
+* `host` : eibd or knxd hostname or ip address (default: 127.0.0.1)
 * `port` : eibd or knxd port (default: 6720)
 * `send_time` : interval to send time and date to the knx bus
 * `time_ga` : groupadress to send a timestamp to the knx bus

--- a/knx/README.md
+++ b/knx/README.md
@@ -15,7 +15,7 @@ This plugin needs a running eibd or knxd.
 knx:
     class_name: KNX
     class_path: plugins.knx
-    # ip: 127.0.0.1
+    # host: 127.0.0.1
     # port: 6720
     # send_time: 600    # update date/time every 600 seconds, default none
     # time_ga: 1/1/1    # default none
@@ -27,8 +27,7 @@ knx:
 
 #### Attributes
 
-* `host` : eibd or knxd hostname. Overrides parameter `ip`, if both are given
-* `ip`   : eibd or knxd ip address (default: 127.0.0.1)
+* `host` : eibd or knxd hostname or ip address (default: 127.0.0.1)
 * `port` : eibd or knxd port (default: 6720)
 * `send_time` : interval to send time and date to the knx bus
 * `time_ga` : groupadress to send a timestamp to the knx bus

--- a/knx/README.md
+++ b/knx/README.md
@@ -15,7 +15,7 @@ This plugin needs a running eibd or knxd.
 knx:
     class_name: KNX
     class_path: plugins.knx
-    # host: 127.0.0.1
+    # ip: 127.0.0.1
     # port: 6720
     # send_time: 600    # update date/time every 600 seconds, default none
     # time_ga: 1/1/1    # default none
@@ -27,7 +27,8 @@ knx:
 
 #### Attributes
 
-* `host` : eibd or knxd hostname or ip address (default: 127.0.0.1)
+* `host` : eibd or knxd hostname. Overrides parameter `ip`, if both are given
+* `ip`   : eibd or knxd ip address (default: 127.0.0.1)
 * `port` : eibd or knxd port (default: 6720)
 * `send_time` : interval to send time and date to the knx bus
 * `time_ga` : groupadress to send a timestamp to the knx bus

--- a/knx/__init__.py
+++ b/knx/__init__.py
@@ -74,7 +74,7 @@ DPT='dpt'
 
 class KNX(lib.connection.Client,SmartPlugin):
     ALLOW_MULTIINSTANCE = True
-    PLUGIN_VERSION = "1.6.0"
+    PLUGIN_VERSION = "1.6.1"
 
 
     # tags actually used by the plugin are shown here

--- a/knx/__init__.py
+++ b/knx/__init__.py
@@ -84,8 +84,6 @@ class KNX(lib.connection.Client,SmartPlugin):
 
     def __init__(self, smarthome):
         self.host = self.get_parameter_value('host')
-        if self.host == 'None':
-            self.host = self.get_parameter_value('ip')
         self.port = self.get_parameter_value('port')
 
         from bin.smarthome import VERSION

--- a/knx/__init__.py
+++ b/knx/__init__.py
@@ -84,6 +84,8 @@ class KNX(lib.connection.Client,SmartPlugin):
 
     def __init__(self, smarthome):
         self.host = self.get_parameter_value('host')
+        if self.host == 'None':
+            self.host = self.get_parameter_value('ip')
         self.port = self.get_parameter_value('port')
 
         from bin.smarthome import VERSION

--- a/knx/plugin.yaml
+++ b/knx/plugin.yaml
@@ -60,10 +60,17 @@ parameters:
 
     host:
         type: str
+        default: ''
+        description:
+            de: 'Hostname des Computers auf dem der EIB Daemon bzw. KNX Daemon läuft. Überschreibt den Parameter "ip", wenn beide angegeben sind.'
+            en: 'hostname of the computer the eib daemon or knx daemon is running on. Overrides the "ip" parameter, if both are given.'
+
+    ip:
+        type: ipv4
         default: '127.0.0.1'
         description:
-            de: 'IP Adresse oder Hostname des Computers auf dem der EIB Daemon bzw. KNX Daemon läuft. Standard: Auf dem Computer auf dem SmartHomeMG läuft.'
-            en: 'IP address or hostname of the computer the eib daemon or knx daemon is running on. Default: The Daemon is running on the computer SmartHomeNG is running on.'
+            de: 'IP Adresse des Computers auf dem der EIB Daemon bzw. KNX Daemon läuft. Standard: Auf dem Computer auf dem SmartHomeMG läuft.'
+            en: 'IP address of the computer the eib daemon or knx daemon is running on. Default: The Daemon is running on the computer SmartHomeNG is running on.'
 
     port:
         type: int

--- a/knx/plugin.yaml
+++ b/knx/plugin.yaml
@@ -59,18 +59,11 @@ parameters:
             en: "If set to 'on'/'true' every KNX packet will be logged to the default plugin logger. If set to 'logger', all knx messages will be logged to a separate logger 'knx_busmonitor'"
 
     host:
-        type: str
-        default: ''
-        description:
-            de: 'Hostname des Computers auf dem der EIB Daemon bzw. KNX Daemon läuft. Überschreibt den Parameter "ip", wenn beide angegeben sind.'
-            en: 'hostname of the computer the eib daemon or knx daemon is running on. Overrides the "ip" parameter, if both are given.'
-
-    ip:
-        type: ipv4
+        type: ip
         default: '127.0.0.1'
         description:
-            de: 'IP Adresse des Computers auf dem der EIB Daemon bzw. KNX Daemon läuft. Standard: Auf dem Computer auf dem SmartHomeMG läuft.'
-            en: 'IP address of the computer the eib daemon or knx daemon is running on. Default: The Daemon is running on the computer SmartHomeNG is running on.'
+            de: 'IP Adresse oder Hostname des Computers auf dem der EIB Daemon bzw. KNX Daemon läuft. Standard: Auf dem Computer auf dem SmartHomeMG läuft.'
+            en: 'IP address or hostname of the computer the eib daemon or knx daemon is running on. Default: The Daemon is running on the computer SmartHomeNG is running on.'
 
     port:
         type: int

--- a/knx/plugin.yaml
+++ b/knx/plugin.yaml
@@ -12,7 +12,7 @@ plugin:
 #    keywords: iot xyz
     documentation: http://smarthomeng.de/user/plugins/knx/user_doc.html
 
-    version: 1.6.0                 # Plugin version
+    version: 1.6.1                 # Plugin version
     sh_minversion: 1.5e            # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True           # plugin supports multi instance
@@ -59,11 +59,11 @@ parameters:
             en: "If set to 'on'/'true' every KNX packet will be logged to the default plugin logger. If set to 'logger', all knx messages will be logged to a separate logger 'knx_busmonitor'"
 
     host:
-        type: ipv4
+        type: str
         default: '127.0.0.1'
         description:
-            de: 'IP Adresse des Computers auf dem der EIB Daemon bzw. KNX Daemon läuft. Standard: Auf dem Computer auf dem SmartHomeMG läuft.'
-            en: 'IP address of the computer the eib daemon or knx daemon is running on. Default: The Daemon is running on the computer SmartHomeNG is running on.'
+            de: 'IP Adresse oder Hostname des Computers auf dem der EIB Daemon bzw. KNX Daemon läuft. Standard: Auf dem Computer auf dem SmartHomeMG läuft.'
+            en: 'IP address or hostname of the computer the eib daemon or knx daemon is running on. Default: The Daemon is running on the computer SmartHomeNG is running on.'
 
     port:
         type: int


### PR DESCRIPTION
added support for using hostname instead of ip address for "host" parameter of plugin config. Adjusted documentation accordingly