### PR TITLE
[RCswitch]: Add Hostname support

### DIFF
--- a/rcswitch/README.md
+++ b/rcswitch/README.md
@@ -173,7 +173,7 @@ rc:
 #### Attributes
 * `rcswitch_dir`: has to point to the directory where the rcswitch-pi send command can be found.
 * `rcswitch_sendDuration`: intended for trouble shooting. Increase this parameter in case switching several power plugs at the same time does not work reliable. Background: In case several power plugs (with different codes / device numbers) shall be switched at the same time, there must be a short gap between sending the serval commands. Otherwise, the several send commands are executed in parallel, gernerating jam on the rc signal.
-* `rcswitch_host`: in case rcswitch is running on a remote machine, the IPv4 address has to be specified. Note: a SSH server has to be installed on the remote machine.
+* `rcswitch_host`: in case rcswitch is running on a remote machine, the IPv4 address or the HOSTNAME has to be specified. Note: a SSH server has to be installed on the remote machine.
 * `rcswitch_user`: user on the remote machine
 * `rcswitch_password`: password for the user on the remote machine
 
@@ -248,6 +248,9 @@ sudo reboot
 
 ### v0.3
 * add import os at the init
+
+### v1.2.0.4
+* add hostname support
 ----------------------------
 ## Further information
 For discussion see https://knx-user-forum.de/forum/supportforen/smarthome-py/39094-logic-und-howto-für-433mhz-steckdosen

--- a/rcswitch/__init__.py
+++ b/rcswitch/__init__.py
@@ -32,13 +32,13 @@ import shlex
 class RCswitch(SmartPlugin):
 
 	ALLOW_MULTIINSTANCE = False
-	PLUGIN_VERSION = "1.2.0.3"
+	PLUGIN_VERSION = "1.2.0.4"
 
 	def __init__(self, smarthome, rcswitch_dir='/usr/local/bin/rcswitch-pi', rcswitch_sendDuration='0.5', rcswitch_host='', rcswitch_user='', rcswitch_password=''):
 		self.logger = logging.getLogger(__name__)
 		self.setupOK = True
 		self.mapping = {'a':1,'A':1,'b':2,'B':2,'c':3,'C':3,'d':4,'D':4,'e':5,'E':5}
-		self._sh=smarthome
+		self._sh = smarthome
 		
 		# format path: cut possible '/' at end of rcswitch_dir parameter
 		if rcswitch_dir[len(rcswitch_dir)-1] == '/':
@@ -54,7 +54,7 @@ class RCswitch(SmartPlugin):
 			self.logger.warning('RCswitch: Argument {} for rcswitch_sendDuration is not a valid number. Using default value instead.'.format(rcswitch_sendDuration))
 		
 		# Handle host
-		if self.is_ip(rcswitch_host) and rcswitch_host != '127.0.0.1':
+		if ((rcswitch_host and self.is_hostname(rcswitch_host)) or (self.is_ip(rcswitch_host) and rcswitch_host != '127.0.0.1')):
 			#check connection to remote host and accept fingerprint
 			try:
 				# following line shall raise an error in case connection is not possible. 

--- a/rcswitch/__init__.py
+++ b/rcswitch/__init__.py
@@ -22,6 +22,7 @@
 import logging
 from lib.model.smartplugin import SmartPlugin
 from datetime import datetime, timedelta
+from socket import gethostname
 import time
 import threading
 import subprocess
@@ -53,8 +54,12 @@ class RCswitch(SmartPlugin):
 			self.sendDuration = float(0.5)
 			self.logger.warning('RCswitch: Argument {} for rcswitch_sendDuration is not a valid number. Using default value instead.'.format(rcswitch_sendDuration))
 		
-		# Handle host
-		if ((rcswitch_host and self.is_hostname(rcswitch_host)) or (self.is_ip(rcswitch_host) and rcswitch_host != '127.0.0.1')):
+		# Handle host, check if anything is defined in rcswitch_host parameter and if is valid hostname or valid IPv4 adress
+		if (rcswitch_host and (self.is_hostname(rcswitch_host) or self.is_ipv4(rcswitch_host))):
+			# then check if user defined its own local host -> error
+			if ((rcswitch_host == gethostname()) or (rcswitch_host == '127.0.0.1')):
+				self.logger.error('RCswitch: rcswitch_host is defined as your own machine, not the remote adress! Please check the parameter rcswitch_host, >>{}<< seems to be not correct!'.format(rcswitch_host))
+
 			#check connection to remote host and accept fingerprint
 			try:
 				# following line shall raise an error in case connection is not possible. 

--- a/rcswitch/plugin.yaml
+++ b/rcswitch/plugin.yaml
@@ -6,15 +6,15 @@ plugin:
         de: 'Schalten von 433 MHz Funksteckdosen'
         en: 'Support for 433 MHz wireless sockets'
     maintainer: dafra
-    tester: '?'                   # Who tests this plugin?
+    tester: hasenradball          # Who tests this plugin?
     state: ready
 #    keywords: iot xyz
 #    documentation: https://github.com/smarthomeNG/smarthome/wiki/CLI-Plugin        # url of documentation (wiki) page
     support: https://knx-user-forum.de/forum/supportforen/smarthome-py/39094-logic-und-howto-für-433mhz-steckdosen
 
-    version: 1.2.0.3              # Plugin version
+    version: 1.2.0.4              # Plugin version
     sh_minversion: 1.2            # minimum shNG version to use this plugin
-#    sh_maxversion:                # maximum shNG version to use this plugin (leave empty if latest)
+#    sh_maxversion:               # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False         # plugin supports multi instance
     restartable: unknown
     classname: RCswitch           # class containing the plugin
@@ -42,9 +42,9 @@ parameters:
         type: str
         default: ''
         description:
-            de: "IP des rcswitch hosts, falls nicht das System auf dem SamrtHomeNG läuft. Achtung: Auf dem Remote \
-                 Host muss ein SSH Server installiert sein."
-            en: "ip of rcswitch host, in case rcswitch is running on a remote machine, the IPv4 address has to be \
+            de: "IP oder HOSTNAME des rcswitch hosts, falls das System nicht auf dieser SmartHomeNG-Maschine läuft. \
+                Achtung: Auf dem Remote Host muss ein SSH Server installiert sein."
+            en: "IP or HOSTNAME of rcswitch host, in case rcswitch is running on a remote machine, if IP the IPv4 address has to be \
                  specified. Note: a SSH server has to be installed on the remote machine."
 
     rcswitch_user:

--- a/rcswitch/plugin.yaml
+++ b/rcswitch/plugin.yaml
@@ -39,7 +39,7 @@ parameters:
             en: "Minimum time in s between sending commands"
 
     rcswitch_host:
-        type: str
+        type: ip
         default: ''
         description:
             de: "IP oder HOSTNAME des rcswitch hosts, falls das System nicht auf dieser SmartHomeNG-Maschine läuft. \


### PR DESCRIPTION
Add hostname support for switching via remote machine.
Now Hostname or IPv4 adress is possible for optional parameter `rcswitch_host`
Example:
`rcswitch_host: 192.178.165.23`
`rcswitch_host: pi-smarthome1`