### PR TITLE
Corrected processing of negative 16-bit register values

### DIFF
--- a/trovis557x/__init__.py
+++ b/trovis557x/__init__.py
@@ -162,7 +162,7 @@ class trovis557x(SmartPlugin):
         return found
 
 
-    # Variablen etc initialisieren (wird wird von __init__ gerufen)
+    # Variablen etc initialisieren (wird von __init__ gerufen)
     def init_vars(self):
         
         self._model = self.get_parameter_value('model')
@@ -186,7 +186,7 @@ class trovis557x(SmartPlugin):
         self._trovis_itemlist = {}
 
 
-    # Schnittstelle initialisieren (wird wird von __init__ gerufen)
+    # Schnittstelle initialisieren (wird von __init__ gerufen)
     def init_trovis(self):
         try:
             # self._modbus_debug = False  #ToDo
@@ -268,10 +268,16 @@ class trovis557x(SmartPlugin):
                 wert = str('{0:.'+str(digits)+'f}').format((buswert*faktor)/10**digits)
 
             elif typ == 'Zahl':
-                if digits == 0:
-                    wert = int(str('{0:.'+str(digits)+'f}').format((buswert*faktor)))
+                busmin = int(alle_details['Busmin'])
+                # 16bit-Register auf negativen Wert prüfen (z.B. Temperaturen)
+                if busmin < 0 and buswert > 32767:
+                    signed_int = buswert - 65536
                 else:
-                    wert = float(str('{0:.'+str(digits)+'f}').format((buswert*faktor)))
+                    signed_int = buswert
+                if digits == 0:
+                    wert = int(str('{0:.'+str(digits)+'f}').format((signed_int*faktor)))
+                else:
+                    wert = float(str('{0:.'+str(digits)+'f}').format((signed_int*faktor)))
 
             elif typ == 'Datum':
                 if len(str(buswert)) == 3:


### PR DESCRIPTION
There was no special handling for those few 16bit registers that can hold negative values (signed INT's).
Therefore, negative temperatures resulted in ridiculous values, like 6.552,7°C outside temperature instead of a real reading of -0.8°C.

Also, fixed some doublettes in comments.