### PR TITLE
Telegram: Removed error message when welcome_msg or bye_msg is empty

### DIFF
--- a/telegram/__init__.py
+++ b/telegram/__init__.py
@@ -65,7 +65,7 @@ MESSAGE_TAG_DEST          = '[DEST]'
 
 
 class Telegram(SmartPlugin):
-    PLUGIN_VERSION = "1.6.1"
+    PLUGIN_VERSION = "1.6.2"
 
     _items = []              # Storage Array for all items using telegram attributes ITEM_ATTR_MESSAGE
     _items_info = {}         # dict used whith the info-command: key = attribute_value, val= item_list ITEM_ATTR_INFO

--- a/telegram/__init__.py
+++ b/telegram/__init__.py
@@ -171,8 +171,9 @@ class Telegram(SmartPlugin):
             except Exception as e:
                 self.logger.warning("Error '{}' occurred. Could not assign pretty names to Telegrams threads, maybe object model of python-telegram-bot module has changed? Please inform the author of plugin!".format(e))
         self.logger.debug("started polling the updater, Queue is {}".format(q))
-        self.msg_broadcast(self._welcome_msg)
-        self.logger.debug("sent welcome message {}")
+        if self._welcome_msg:
+          self.msg_broadcast(self._welcome_msg)
+          self.logger.debug("sent welcome message {}")
 
     def stop(self):
         """
@@ -181,8 +182,9 @@ class Telegram(SmartPlugin):
         self.alive = False
         try:
             self.logger.debug("stop telegram plugin")
-            self.msg_broadcast(self._bye_msg)
-            self.logger.debug("sent bye message")
+            if self._bye_msg:
+              self.msg_broadcast(self._bye_msg)
+              self.logger.debug("sent bye message")
             self._updater.stop()
             self.logger.debug("telegram plugin stopped")
         except:

--- a/telegram/plugin.yaml
+++ b/telegram/plugin.yaml
@@ -12,7 +12,7 @@ plugin:
     documentation: http://smarthomeng.de/user/plugins/telegram/user_doc.html
 #    support: https://knx-user-forum.de/forum/supportforen/smarthome-py
 
-    version: 1.6.1                  # Plugin version
+    version: 1.6.2                  # Plugin version
     sh_minversion: 1.3              # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True            # plugin supports multi instance
@@ -46,15 +46,15 @@ parameters:
         type: str
         default: 'SmarthomeNG Telegram Plugin is up and running'
         description:
-            de: 'Willkommensnachricht, wird an alle vertrauenswürdigen Clients beim Start des Plugins gesendet'
-            en: 'Welcome message, will be sent to all trusted chat clients at plugin start'
+            de: 'Willkommensnachricht, wird an alle vertrauenswürdigen Clients beim Start des Plugins gesendet. Ist der Wert leer, wird keine Willkommensnachricht gesendet.'
+            en: 'Welcome message, will be sent to all trusted chat clients at plugin start. An empty value indicates that no welcome message is sent.'
 
     bye_msg:
         type: str
         default: 'SmartHomeNG Telegram Plugin stops'
         description:
-            de: 'Endenachricht, wird an alle vertrauenswürdigen Clients beim Stop des Plugins gesendet'
-            en: 'Bye message, will be sent to all trusted chat clients at plugin stop'
+            de: 'Endenachricht, wird an alle vertrauenswürdigen Clients beim Stop des Plugins gesendet.  Ist der Wert leer, wird keine Endenachricht gesendet.'
+            en: 'Bye message, will be sent to all trusted chat clients at plugin stop.  An empty value indicates that no by message is sent.'
 
     no_access_msg:
         type: str


### PR DESCRIPTION
Currently, using the Telegram plugin with this configuration:

    telegram:
      class_name: Telegram
      class_path: plugins.telegram
      name: <something>
      token: <top secret>
      welcome_msg: ""
      bye_msg: ""

yields the error message 

    2020-01-04  17:15:51 ERROR    plugins.telegram    could not broadcast to chat id [...] due to error Message text is empty

This PR corrects this and allows empty (and hence disabled) welcome and bye messages without error.