### PR TITLE
thz: Add missing method

### DIFF
--- a/thz/PortHandler.py
+++ b/thz/PortHandler.py
@@ -240,3 +240,13 @@ class PortHandler(threading.Thread):
         except:
             self._fd = None
             return False
+    def closePort(self):
+        """attempts to close the serial port"""
+        try:
+            self._fd.close()
+            self._fd = None
+            self.logger.info('Closed serial port.')
+            return True
+        except:
+            self._fd = None
+            return False


### PR DESCRIPTION
The THZ plugin had a problem with the serial connection to my heatpump:

```
ERROR    plugins.thz.THZ Heat pump did not respond for 10 seconds
WARNING  plugins.thz.THZ (<class 'AttributeError'>, AttributeError("'PortHandler' object has no attribute 'closePort'",), <traceback object at 0x7fd34c03aa88>)
```

I figured the `closePort ` method should close the port, so i added the missing method in PortHandler.py.
I don't know if we need exception handling there and also I couldn't test it yet, but I'm quite sure the method should be there as it is called here: https://github.com/smarthomeNG/plugins/blob/80e41af31ed53e405d5e89ed7091ffc4696c71d9/thz/ThzProtocol.py#L1254