### PR TITLE
Plugin iCal: added handling of logging login data in calendar uris

### DIFF
--- a/ical/README.md
+++ b/ical/README.md
@@ -1,6 +1,9 @@
 # iCal
 
 ## Changelog
+1.5.4:
+- added parameter handle_login to control logging of calendar uri login data.
+
 1.5.3:
 - fixed conversion from calendar defined timezones in smarthomeNG configured timezone.
 

--- a/ical/plugin.yaml
+++ b/ical/plugin.yaml
@@ -20,7 +20,7 @@ plugin:
 #    documentation: https://github.com/smarthomeNG/smarthome/wiki/CLI-Plugin        # url of documentation (wiki) page
     support: https://knx-user-forum.de/forum/supportforen/smarthome-py/1352089-support-thread-zum-ical-plugin
 
-    version: 1.5.3                 # Plugin version
+    version: 1.5.4                 # Plugin version
     sh_minversion: 1.5             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
@@ -59,6 +59,20 @@ parameters:
             Beispiel: holidays:http://cal.server/holidays.ics"
             en: "list of calendars to automatically keep up to date and provided via `sh.ical()` function. Configures an alias (optional) and the URI of calendar, which can be a local file or a remote file when starting with `https://`. Online calendars are downloaded in the folder var/ical and updated depending on the cycle attribute.\n
             Example: holidays:https://cal.server/holidays.ics"
+
+    handle_login:
+        type: str
+        default: 'mask'
+        valid_list:
+            - 'mask'
+            - 'show'
+            - 'strip'
+        description:
+            de: "Umgang mit Login-Daten (http://user:pass@domain.tld/path) in Kalender-URIs in Logs."
+            en: "Handling of login data (http://user:pass@domain.tld/path) in calendar uris in logs."
+        description_long:
+            de: "Umgang mit Login-Daten (http://user:pass@domain.tld/path) in Kalender-URIs in Logs. 'mask' ersetzt die Login-Daten durch '***', 'show' gibt sie ins Log aus und 'strip' löscht den jeweiligen Teil der URI vor Ausgabe ins Log."
+            en: "Handling of login data (http://user:pass@domain.tld/path) in calendar uris in logs. 'mask' replaces login data with '***', 'show' prints login data to the log, 'strip' removes login data before logging."
 
 item_attributes:
     # Definition of item attributes defined by this plugin


### PR DESCRIPTION
iCal calendar uris can have embedded login data, e.g. https://user:password@domain.tld/path
It might not be advisable to output this login data to logfiles.

The new plugin configuration parameter handle_login can be
'show': output login data (current behaviour) -> https://user:password@domain.tld/path
'mask': replace login data with '***' respectively -> https://***:***@domain.tld/path
'strip': strip login data completely -> https://domain.tld/path

default is 'mask', which changes default behaviour, but is a safe preset

Check and handling is located in iCal._clean_uri() which is in turn called before logging calendar data. Attention must be paid if future additional logging is done.