### PR TITLE
XMPP: Replace sleekxmpp with slixmpp

### DIFF
--- a/xmpp/README.md
+++ b/xmpp/README.md
@@ -68,6 +68,95 @@ Description of the attributes:
 * use_ipv6: enable IPv6 support, which is the default
 * plugins: list of plugins (XEP to support)
 
+#### XEP supported
+
+- XEP-0004: Data Forms
+- XEP-0009: Jabber-RPC
+- XEP-0012: Last Activity
+- XEP-0013: Flexible Offline Message Retrieval
+- XEP-0016: Privacy Lists
+- XEP-0020: Feature Negotiation
+- XEP-0027: Current Jabber OpenPGP Usage
+- XEP-0030: Service Discovery
+- XEP-0033: Extended Stanza Addressing
+- XEP-0045: Multi-User Chat
+- XEP-0047: In-band Bytestreams
+- XEP-0048: Bookmarks
+- XEP-0049: Private XML Storage
+- XEP-0050: Ad-Hoc Commands
+- XEP-0054: vcard-temp
+- XEP-0059: Result Set Management
+- XEP-0060: Publish-Subscribe
+- XEP-0065: SOCKS5 Bytestreams"
+- XEP-0066: Out of Band Data
+- XEP-0070: Verifying HTTP Requests via XMPP
+- XEP-0071: XHTML-IM
+- XEP-0077: In-Band Registration
+- XEP-0078: Non-SASL Authentication
+- XEP-0079: Advanced Message Processing
+- XEP-0080: User Location
+- XEP-0082: XMPP Date and Time Profiles
+- XEP-0084: User Avatar
+- XEP-0085: Chat State Notifications
+- XEP-0086: Error Condition Mappings
+- XEP-0091: Legacy Delayed Delivery
+- XEP-0092: Software Version
+- XEP-0095: Stream Initiation
+- XEP-0096: SI File Transfer
+- XEP-0106: JID Escaping
+- XEP-0107: User Mood
+- XEP-0108: User Activity
+- XEP-0115: Entity Capabilities
+- XEP-0118: User Tune
+- XEP-0122: Data Forms Validation
+- XEP-0128: Service Discovery Extensions
+- XEP-0131: Stanza Headers and Internet Metadata
+- XEP-0133: Service Administration
+- XEP-0138: Compression"
+- XEP-0152: Reachability Addresses
+- XEP-0153: vCard-Based Avatars
+- XEP-0163: Personal Eventing Protocol (PEP)
+- XEP-0172: User Nickname
+- XEP-0184: Message Delivery Receipts
+- XEP-0186: Invisible Command
+- XEP-0191: Blocking Command
+- XEP-0196: User Gaming
+- XEP-0198: Stream Management
+- XEP-0199: XMPP Ping
+- XEP-0202: Entity Time
+- XEP-0203: Delayed Delivery
+- XEP-0221: Data Forms Media Element
+- XEP-0222: Persistent Storage of Public Data via PubSub
+- XEP-0223: Persistent Storage of Private Data via PubSub
+- XEP-0224: Attention
+- XEP-0231: Bits of Binary
+- XEP-0235: OAuth Over XMPP
+- XEP-0242: XMPP Client Compliance 2009
+- XEP-0249: Direct MUC Invitations
+- XEP-0256: Last Activity in Presence
+- XEP-0257: Client Certificate Management for SASL EXTERNAL
+- XEP-0258: Security Labels in XMPP
+- XEP-0270: XMPP Compliance Suites 2010
+- XEP-0279: Server IP Check
+- XEP-0280: Message Carbons
+- XEP-0297: Stanza Forwarding
+- XEP-0300: Use of Cryptographic Hash Functions in XMPP
+- XEP-0302: XMPP Compliance Suites 2012
+- XEP-0308: Last Message Correction
+- XEP-0313: Message Archive Management
+- XEP-0319: Last User Interaction in Presence
+- XEP-0323 Internet of Things - Sensor Data
+- XEP-0325 Internet of Things - Control
+- XEP-0332: HTTP over XMPP transport
+- XEP-0333: Chat Markers
+- XEP-0334: Message Processing Hints
+- XEP-0335: JSON Containers
+- XEP-0352: Client State Indication
+- XEP-0363: HTTP File Upload
+- XEP-0380: Explicit Message Encryption
+- XEP-0394: Message Markup
+
+
 ### logic.yaml
 At this stage there are no specific logic files. But in order to use this module you can create a logic file for another attribute and execute
 or send messages to your xmpp account via sh.xmpp.send

--- a/xmpp/README.md
+++ b/xmpp/README.md
@@ -2,10 +2,13 @@
 
 ## Requirements/Description
 
-This Plugin uses sleekxmpp as basis to connect to XMPP etc services: https://pypi.python.org/pypi/sleekxmpp
+This Plugin uses slixmpp as basis to connect to XMPP etc services: https://pypi.org/project/slixmpp/
 
-At this stage the XMPP plugin module only supports in sending messages. Recevied messages are ignored. OTR not supported
-as the sleekxmpp libraries do not support this as yet.
+At this stage the XMPP plugin module only supports sending messages.
+Recevied messages are ignored.
+
+In case you want some OTR you have to install https://pypi.org/project/slixmpp-omemo/
+and use this XEP-384 from there (currently only possible via manual installation).
 
 This Plugin can also be used to setup a standard logger category which
 can be used to log messages using XMPP to some chat or groupchat contact.

--- a/xmpp/__init__.py
+++ b/xmpp/__init__.py
@@ -24,7 +24,7 @@
 #########################################################################
 
 import logging
-import sleekxmpp
+import slixmpp
 
 from lib.plugin import Plugins
 from lib.model.smartplugin import *
@@ -53,7 +53,7 @@ class XMPP(SmartPlugin):
         if len(joins) and 'xep_0045' not in plugins:
             plugins.append('xep_0045')
 
-        self.xmpp = sleekxmpp.ClientXMPP(jid, password)
+        self.xmpp = slixmpp.ClientXMPP(jid, password)
         for plugin in plugins:
             self.xmpp.register_plugin(plugin)
         self.xmpp.use_ipv6 = self.get_parameter_value('use_ipv6')
@@ -69,13 +69,13 @@ class XMPP(SmartPlugin):
             self.xmpp.connect(address=self._server)
         else:
             self.xmpp.connect()
-        self.xmpp.process(threaded=True)
+        self.xmpp.process()
 
     def stop(self):
         self._run = False
         self.alive = False
         for chat in self._join:
-            self.xmpp.plugin['xep_0045'].leaveMUC(chat, self.xmpp.boundjid.bare)
+            self.xmpp.plugin['xep_0045'].leave_muc(chat, self.xmpp.boundjid.bare)
         self.logger.info("Shutting Down XMPP Client")
         self.xmpp.disconnect(wait=False)
 
@@ -98,10 +98,10 @@ class XMPP(SmartPlugin):
 
     def handleXMPPConnected(self, event):
         try:
-            self.xmpp.sendPresence(pstatus="Send me a message")
+            self.xmpp.send_presence(pstatus="Send me a message")
             self.xmpp.get_roster()
             for chat in self._join:
-                self.xmpp.plugin['xep_0045'].joinMUC(chat, self.xmpp.boundjid.bare, wait=True)
+                self.xmpp.plugin['xep_0045'].join_muc(chat, self.xmpp.boundjid.bare, wait=True)
         except Exception as e:
             self.logger.error("XMPP: Reconnecting, because can not set/get presence/roster: {}".format(e))
             self.xmpp.reconnect()

--- a/xmpp/__init__.py
+++ b/xmpp/__init__.py
@@ -5,6 +5,7 @@
 #########################################################################
 # Copyright 2015 KNX-User-Forum e.V.            http://knx-user-forum.de/
 # By Skender Haxhimolla 2015
+# By Oliver Hinckel 2020-
 #########################################################################
 #  This file is part of SmartHomeNG.   https://github.com/smarthomeNG/
 #
@@ -31,7 +32,7 @@ from lib.model.smartplugin import *
 
 class XMPP(SmartPlugin):
 
-    PLUGIN_VERSION = "1.4.0"
+    PLUGIN_VERSION = "1.4.1"
     ALLOW_MULTIINSTANCE = False
 
     def __init__(self, smarthome, jid, password, logic='XMPP'):

--- a/xmpp/plugin.yaml
+++ b/xmpp/plugin.yaml
@@ -12,7 +12,7 @@ plugin:
 #    documentation: https://github.com/smarthomeNG/plugins/blob/develop/mqtt/README.md        # url of documentation (wiki) page
 
 # Following entries are for Smart-Plugins:
-    version: 1.4.0                 # Plugin version
+    version: 1.4.1                 # Plugin version
     sh_minversion: 1.3             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False

--- a/xmpp/plugin.yaml
+++ b/xmpp/plugin.yaml
@@ -68,10 +68,11 @@ logic_parameters: NONE
 plugin_functions:
     # Definition of function interface of the plugin
     send:
+        type: void
         description:
             de: 'Eine Messgae via xmpp senden'
             en: 'Send a message via xmpp'
-        parameter:
+        parameters:
             to:
                 type: str
                 description:

--- a/xmpp/plugin.yaml
+++ b/xmpp/plugin.yaml
@@ -12,7 +12,7 @@ plugin:
 #    documentation: https://github.com/smarthomeNG/plugins/blob/develop/mqtt/README.md        # url of documentation (wiki) page
 
 # Following entries are for Smart-Plugins:
-    version: 1.3.3                 # Plugin version
+    version: 1.4.0                 # Plugin version
     sh_minversion: 1.3             # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False

--- a/xmpp/requirements.txt
+++ b/xmpp/requirements.txt
@@ -1,1 +1,1 @@
-sleekxmpp>=1.3.1
+slixmpp>=1.5.2


### PR DESCRIPTION
The XMPP Python library [sleekxmpp](https://github.com/fritzy/SleekXMPP) is no longer maintained the the repository is archived. There's a replacement library called [slixmpp](https://github.com/poezio/slixmpp).

Changing the XMPP plugin to use the new library (with some adjustments to the methods used). But mostly it seems to be compatible.
