### PR TITLE
plugin alexarc4shng: Unused code

### DIFF
--- a/alexarc4shng/__init__.py
+++ b/alexarc4shng/__init__.py
@@ -265,13 +265,6 @@ class AlexaRc4shNG(SmartPlugin):
         # Nur bei Wertänderung, sonst nix wie raus hier
         if(oldValue == newValue):
             return         
-        
-        
-        try:
-            myEchos = self.sh.alexarc4shng.Echos.all()
-            
-        except Exception as err:
-            self.logger.debug("Error while getting Echos :",err)
         # End Test
         
 


### PR DESCRIPTION
In __init__.py around line 271 we find:
```
try:
    myEchos = self.sh.alexarc4shng.Echos.all()
except Exception as err:
    self.logger.debug("Error while getting Echos :",err)
```
Isn't that working only when the plugin is named "alexarc4shng"?
In the plugins README.md it is written:
`plugin_name -> fix AlexaRc4shNG`

So it must be accessed by
`self.sh.AlexaRc4shNG.Echos.all()`
or?

And right, when I debug through it it still throws an exception:
`AttributeError("'SmartHome' object has no attribute 'alexarc4shng'")`

Because myEcho isn't used afterwards anyway it can be removed ...