### PR TITLE
Avoid exceptions when lastconditionset/lastconditionset_name item is not set

### DIFF
--- a/stateengine/StateEngineItem.py
+++ b/stateengine/StateEngineItem.py
@@ -72,7 +72,7 @@ class SeItem:
 
     @property
     def lastconditionset(self):
-        return self.__lastconditionset_item_id.property.value
+        return None if self.__lastconditionset_item_id is None else self.__lastconditionset_item_id.property.value
 
     @property
     def laststate_name(self):
@@ -80,7 +80,7 @@ class SeItem:
 
     @property
     def lastconditionset_name(self):
-        return self.__lastconditionset_item_name.property.value
+        return None if self.__lastconditionset_item_name is None else self.__lastconditionset_item_name.property.value
 
     @property
     def action_in_progress(self):


### PR DESCRIPTION
If the items lastconditionset/lastconditionset_name are not set and one tries to generate the graph in the web interface an exception occurs.
The pull request avoids the exception. The graph is generated.