### PR TITLE
knx plugin: add DPT 251.600 RGBW

### DIFF
--- a/hue/__init__.py
+++ b/hue/__init__.py
@@ -478,10 +478,10 @@ class HUE(SmartPlugin):
                 # lampe ist an (status in sh). dann können alle befehle gesendet werden
                 if hueSendGroup == 'on':
                     # wenn der status in sh true ist, aber mit dem befehl on, dann muss die lampe auf der hue seite erst eingeschaltet werden
-                    if hueIndex + '.bri' in self._sendLampItems:
+                    if hueIndex + '.bri' in self._sendGroupItems:
                         # wenn eingeschaltet wird und ein bri item vorhanden ist, dann wird auch die hellgkeit
                         # mit gesetzt, weil die gruppe das im ausgeschalteten zustand vergisst.
-                        self._set_group_state(hueBridgeId, hueGroupId, {'on': True, 'bri': int(self._sendLampItems[(hueIndex + '.bri')]()) , 'transitiontime': hueTransitionTime})
+                        self._set_group_state(hueBridgeId, hueGroupId, {'on': True, 'bri': int(self._sendGroupItems[(hueIndex + '.bri')]()) , 'transitiontime': hueTransitionTime})
                     else:
                         # ansonst wird nur eingeschaltet
                         self._set_group_state(hueBridgeId, hueGroupId, {'on': True , 'transitiontime': hueTransitionTime})

--- a/knx/dpts.py
+++ b/knx/dpts.py
@@ -442,6 +442,20 @@ def de232(payload):
     return list(struct.unpack('>BBB', payload))
 
 """
+Datapoint Types U8U8U8U8
+    251.600 DPT_Colour_RGBW
+"""
+
+def en251(value):
+    return [0, 0xff, 0x0f, int(value[0]) & 0xff, int(value[1]) & 0xff, int(value[2]) & 0xff, int(value[3]) & 0xff]
+
+
+def de251(payload):
+    if len(payload) != 6:
+        return None
+    return list(struct.unpack('>lBB', payload))
+
+"""
 Datapoint type with eight bytes F16F16F16F16
     275.100 DPT_TempRoomSetpSetF16[4]
     Item Value then is a list of four F16 values
@@ -528,6 +542,7 @@ decode = {
     '28.001': de28,     #DPT_UTF-8
     '229': de229,
     '232': de232,
+    '251': de251,       #RGBW
     '275.100' : de275100,
     'pa': depa,
     'ga': dega
@@ -581,6 +596,7 @@ encode = {
     '28.001': en28,     #DPT_UTF-8
     '229': en229,
     '232': en232,       #RGB
+    '251': en251,       #RGBW
     '275.100' : en275100,   # Setpoint temperature, contains 4 values: Komfort, Standby, Night and Frost
     'ga': enga
 }

--- a/knx/plugin.yaml
+++ b/knx/plugin.yaml
@@ -162,6 +162,7 @@ item_attributes:
          - '24'
          - '229'
          - '232'
+         - '251'
          - '275.100'
         valid_list_description:
             de:
@@ -197,6 +198,7 @@ item_attributes:
              - 'Unlimitierte Zeichenkette [8859_1] (var) -> str'
              - 'Smartmeter Werte Tripel: [Ganzzahl -2147483648 - 2147483647(32 Bit), 0-255 (8 Bit), 0-255 (8 Bit)] (6 Byte) -> list'
              - 'RGB: [0, 0, 0] - [255, 255, 255] (3 Byte) -> list'
+             - 'RGBW: [0, 0, 0, 0] - [255, 255, 255, 255] (4 Byte)-> list'
              - 'Quadrupel mit Solltemperaturen für Komfort, Standby, Nachtabsenkung, Frostschutz (4 Fließkommazahlen mit 16 Bit) -> list'
             en:
              - 'Switch (1 Bit) -> bool'
@@ -231,6 +233,7 @@ item_attributes:
              - 'unlimited string [8859_1] (var) -> str'
              - 'Smartmeter value triple: [Integer -2147483648 - 2147483647(32 Bit), 0-255 (8 Bit), 0-255 (8 Bit)] (6 Byte) -> list'
              - 'RGB: [0, 0, 0] - [255, 255, 255] (3 Byte) -> list'
+             - 'RGBW: [0, 0, 0, 0] - [255, 255, 255, 255] (4 Byte)-> list'
              - 'Quadrupel with set temperatures comfort, standby, night reduction, frost protection (4 float with 16 Bit) -> list'
         description:
             de: 'Dieses Attribut setzt den Typ des KNX-Datenpunktes, der für die Konvertierung der KNX-Nachrichten in das interne SmartHomeNG-Format verwendet wird. Die Angabe ist zwingend erforderlich ist. Wenn Sie keinen Wert angeben, wird das Element vom Plugin ignoriert. Der DPT muss dem Typ des Artikels entsprechen!'
@@ -368,6 +371,7 @@ plugin_functions:
                  - '24'
                  - '229'
                  - '232'
+                 - '251'
                  - '275.100'
                 valid_list_description:
                     de:
@@ -403,6 +407,7 @@ plugin_functions:
                      - 'Unlimitierte Zeichenkette [8859_1] (var) -> str'
                      - 'Smartmeter Werte Tripel: [Ganzzahl -2147483648 - 2147483647(32 Bit), 0-255 (8 Bit), 0-255 (8 Bit)] (6 Byte) -> list'
                      - 'RGB: [0, 0, 0] - [255, 255, 255] (3 Byte) -> list'
+                     - 'RGBW: [0, 0, 0, 0] - [255, 255, 255, 255] (4 Byte)-> list'
                      - 'Quadrupel mit Solltemperaturen für Komfort, Standby, Nachtabsenkung, Frostschutz (4 Fließkommazahlen mit 16 Bit) -> list'
                     en:
                      - 'Switch (1 Bit) -> bool'
@@ -437,6 +442,7 @@ plugin_functions:
                      - 'unlimited string [8859_1] (var) -> str'
                      - 'Smartmeter value triple: [Integer -2147483648 - 2147483647(32 Bit), 0-255 (8 Bit), 0-255 (8 Bit)] (6 Byte) -> list'
                      - 'RGB: [0, 0, 0] - [255, 255, 255] (3 Byte) -> list'
+                     - 'RGBW: [0, 0, 0, 0] - [255, 255, 255, 255] (4 Byte)-> list'
                      - 'Quadrupel with set temperatures comfort, standby, night reduction, frost protection (4 float with 16 Bit) -> list'
                 description:
                     de: "KNX Datenpunkttyp"


### PR DESCRIPTION
Implemented & Tested for MDT DaliControl Gateway
6 Bytes Object, but only the 4 Bytes are actually used according to docu. 
The first 2 Bytes are filled with '0xff' as default values