### PR TITLE
stateengine: Use path instead of name

### DIFF
--- a/stateengine/StateEngineCondition.py
+++ b/stateengine/StateEngineCondition.py
@@ -106,7 +106,7 @@ class SeCondition(StateEngineTools.SeItemChild):
         if 'SeCurrent' in eval_result:
             eval_result = eval_result.split('SeCurrent.')[1].split(' ')[0]
         value_result = str(self.__value.get_for_webif())
-        result = {'item': str(self.__item), 'eval': eval_result, 'value': value_result,
+        result = {'item': self.__item.path(), 'eval': eval_result, 'value': value_result,
                   'min': str(self.__min),
                   'max': str(self.__max), 'agemin': str(self.__agemin), 'agemax': str(self.__agemax),
                   'negate': str(self.__negate), 'agenegate': str(self.__agenegate),


### PR DESCRIPTION
When an item which is referenced in a action has a name, then an error message appears that the item cannot be found. In the error message appears the name of the item:
`2021-02-24  07:23:45 WARNING  plugins.stateengine.stateengine.automatik.rules      Item 'Here is the name of the item' not found!`

The PR uses the path instead of the name to later find the item ...

