### PR TITLE
Wihtings health: callback base url

### DIFF
--- a/withings_health/__init__.py
+++ b/withings_health/__init__.py
@@ -40,6 +40,7 @@ class WithingsHealth(SmartPlugin):
         self._user_id = self.get_parameter_value('user_id')
         self._client_id = self.get_parameter_value('client_id')
         self._consumer_secret = self.get_parameter_value('consumer_secret')
+        self._callback_base_url = self.get_parameter_value('callback_base_url')
         self._cycle = self.get_parameter_value('cycle')
         self._creds = None
         self._client = None
@@ -350,10 +351,13 @@ class WithingsHealth(SmartPlugin):
     def get_callback_url(self):
         ip = self.mod_http.get_local_ip_address()
         port = self.mod_http.get_local_port()
+        base_url = self._callback_base_url
+        if not base_url:
+            base_url = "http://{}:{}".format(ip, port)
         web_ifs = self.mod_http.get_webifs_for_plugin(self.get_shortname())
         for web_if in web_ifs:
             if web_if['Instance'] == self.get_instance_name():
-                callback_url = "http://{}:{}{}".format(ip, port, web_if['Mount'])
+                callback_url = "{}{}".format(base_url, web_if['Mount'])
                 self.logger.debug("WebIf found, callback is {}".format(self.get_fullname(),
                                                                        callback_url))
             return callback_url

--- a/withings_health/plugin.yaml
+++ b/withings_health/plugin.yaml
@@ -44,6 +44,13 @@ parameters:
             de: 'Consumer-Geheimnis von https://account.health.nokia.com/partner/dashboard_oauth2'
             en: 'Consumer secret from https://account.health.nokia.com/partner/dashboard_oauth2'
 
+    callback_base_url:
+        type: str
+        mandatory: False
+        description:
+            de: 'Callback-URL-Basis falls SmarthomeNG nicht direkt aus dem Internet erreichbar ist'
+            en: 'Callback url base, if SmarthomeNG is not directly reachable from internet'
+
     cycle:
         type: int
         default: 300


### PR DESCRIPTION
My smarthomeng is not directly reachable from the internet. Therefore the callback url for authentication is not reachable and authentication is not possible.
Instead I use a proxy to forward the url for the callback to smarthomeng.

This PR adds a new parameter, which allows to specify the basis url for the callback. With this change authentication is possible.
Perhaps it would be even better to specify the full callback url?