### PR TITLE
avm: Handle callmonitor reconnect

### DIFF
--- a/avm/__init__.py
+++ b/avm/__init__.py
@@ -186,7 +186,8 @@ class MonitoringService:
                 self._plugin_instance.logger.error("CallMonitor connection receive error: " + str(e))
                 break
             if not data:
-                self._plugin_instance.logger.error("CallMonitor connection not open anymore.")
+                if self._listen_active:
+                    self._plugin_instance.logger.error("CallMonitor connection not open anymore.")
                 break
             data = data.decode("utf-8")
             self._plugin_instance.logger.debug("Data Received from CallMonitor: %s" % data)


### PR DESCRIPTION
Nearly every night my SmarthomeNG has a connection problem with the fritz box. In this moment an exception occures in the listen thread and the thread terminates. Of couse the call monitor is not working anymore after that.

This commit fixes that behavior as it sets the _listen_active flag to false before terminating the thread. The inherent reconnect behavior then detects this situation and start a new listen thread.

On shutting down SmarthomeNG it stops the listen thread by a rude shutdown of the socket. There is no other way to get in contact with this thread. Alternatively one could set a socket timeout and check for the stop flag ...

Also it now stores a handle to the running listen thread (`start()`still returns None) and uses this for joining.