### PR TITLE
mailrcv plugin: catch exception when trying to close imap

### DIFF
--- a/mailrcv/__init__.py
+++ b/mailrcv/__init__.py
@@ -73,14 +73,20 @@ class IMAP(SmartPlugin):
             return
         if rsp != 'OK':
             self.logger.warning("IMAP: Could not select mailbox")
-            imap.close()
-            imap.logout()
+            try:
+                imap.close()
+                imap.logout()
+            except Exception:
+                pass
             return
         rsp, data = imap.uid('search', None, "ALL")
         if rsp != 'OK':
             self.logger.warning("IMAP: Could not search mailbox")
-            imap.close()
-            imap.logout()
+            try:
+                imap.close()
+                imap.logout()
+            except Exception:
+                pass
             return
         uids = data[0].split()
         for uid in uids:
@@ -152,8 +158,11 @@ class IMAP(SmartPlugin):
                             self.logger.info("No trash mailboxes available")
             else:
                 self.logger.info("Ignoring mail. {0} => {1}: {2}".format(fo, to, subject))
-        imap.close()
-        imap.logout()
+        try:
+            imap.close()
+            imap.logout()
+        except Exception:
+            pass
 
     def run(self):
         self.alive = True


### PR DESCRIPTION

e.g. prevent error message like this:
WARNING  plugins.mailrcv   IMAP: Could not select mailbox
ERROR    plugins.mailrcv.IMAP Method plugins.mailrcv.IMAP exception: command CLOSE illegal in state AUTH, only allowed in states SELECTED
Traceback (most recent call last):
  File "/usr/local/smarthome/lib/scheduler.py", line 664, in _task
    obj()
  File "/usr/local/smarthome/plugins/mailrcv/__init__.py", line 76, in _cycle
    imap.close()
  File "/usr/local/lib/python3.8/imaplib.py", line 466, in close
    typ, dat = self._simple_command('CLOSE')
  File "/usr/local/lib/python3.8/imaplib.py", line 1205, in _simple_command
    return self._command_complete(name, self._command(name, *args))
  File "/usr/local/lib/python3.8/imaplib.py", line 943, in _command
    raise self.error("command %s illegal in state %s, "
imaplib.IMAP4.error: command CLOSE illegal in state AUTH, only allowed in states SELECTED