### PR TITLE
Some updates for the shelly plugin

### DIFF
--- a/shelly/__init__.py
+++ b/shelly/__init__.py
@@ -146,16 +146,20 @@ class Shelly(MqttPlugin):
             if shelly_attr:
                 shelly_attr = shelly_attr.lower()
 
-            # shellyht needs another topic path than the relay devices:
-            if shelly_type == 'shellyht':
+            # shellyht and shellyflood needs another topic path than the relay devices:
+            if shelly_type == 'shellyht' or shelly_type == 'shellyflood':
                 if shelly_attr == 'humidity':
                     topic = 'shellies/' + shelly_id + '/sensor/humidity'
+                elif shelly_attr == 'flood':
+                    topic = 'shellies/' + shelly_id + '/sensor/flood'
                 elif shelly_attr == 'battery':
                     topic = 'shellies/' + shelly_id + '/sensor/battery'
                 elif shelly_attr == 'temp':
                     topic = 'shellies/' + shelly_id + '/sensor/temperature'
                 elif shelly_attr == 'error':
                     topic = 'shellies/' + shelly_id + '/sensor/error'
+                elif shelly_attr == 'online':
+                    topic = 'shellies/' + shelly_id + '/online'
                 else:
                     self.logger.warning("parse_item: unknown attribute shelly_attr = {} for type {}".format(shelly_attr, shelly_type))
             elif shelly_attr in ['relay', None]:

--- a/shelly/__init__.py
+++ b/shelly/__init__.py
@@ -146,10 +146,20 @@ class Shelly(MqttPlugin):
             if shelly_attr:
                 shelly_attr = shelly_attr.lower()
 
-            # shellyht and shellyflood needs another topic path than the relay devices:
-            if shelly_type == 'shellyht' or shelly_type == 'shellyflood':
+            # shellyht, shellydw2 and shellyflood needs another topic path than the relay devices:
+            if shelly_type == 'shellyht' or shelly_type == 'shellydw2' or shelly_type == 'shellyflood':
                 if shelly_attr == 'humidity':
                     topic = 'shellies/' + shelly_id + '/sensor/humidity'
+                elif shelly_attr == 'state':
+                    topic = 'shellies/' + shelly_id + '/sensor/state'
+                elif shelly_attr == 'tilt':
+                    topic = 'shellies/' + shelly_id + '/sensor/tilt'
+                elif shelly_attr == 'vibration':
+                    topic = 'shellies/' + shelly_id + '/sensor/vibration'
+                elif shelly_attr == 'lux':
+                    topic = 'shellies/' + shelly_id + '/sensor/lux'
+                elif shelly_attr == 'illumination':
+                    topic = 'shellies/' + shelly_id + '/sensor/illumination'
                 elif shelly_attr == 'flood':
                     topic = 'shellies/' + shelly_id + '/sensor/flood'
                 elif shelly_attr == 'battery':

--- a/shelly/plugin.yaml
+++ b/shelly/plugin.yaml
@@ -41,6 +41,7 @@ item_attributes:
             - shellyswitch25
             - shelly4pro
             - shellyht
+            - shellydw2
             - shellyflood
         description:
             de: "Typ des Shelly Devices (z.B. Shellyplug, Shellyplug-s, Shelly1/pm, Shelly2, Shelly2.5, Shelly4Pro)"
@@ -58,6 +59,11 @@ item_attributes:
             - temp_f
             - humidity
             - battery
+            - state
+            - tilt
+            - vibration
+            - lux
+            - illumination
             - flood
             - error
         description:
@@ -135,6 +141,57 @@ item_structs:
             shelly_id: ..:.
             shelly_type: ..:.
             shelly_attr: battery
+
+    shellydw2:
+        name: WLAN Tür und Fenster Sensor, mit Temperaturmessung
+        type: str
+        shelly_type: shellydw2
+        shelly_attr: state
+
+        open:
+            type: bool
+            eval: 1 if sh...() == 'open' else 0
+            eval_trigger: ..
+        tilt:
+            type: num
+            shelly_id: ..:.
+            shelly_type: ..:.
+            shelly_attr: tilt
+        vibration:
+            type: num
+            shelly_id: ..:.
+            shelly_type: ..:.
+            shelly_attr: vibration
+        lux:
+            type: num
+            shelly_id: ..:.
+            shelly_type: ..:.
+            shelly_attr: lux
+        illumination:
+            type: str
+            shelly_id: ..:.
+            shelly_type: ..:.
+            shelly_attr: illumination
+        temp:
+            type: num
+            shelly_id: ..:.
+            shelly_type: ..:.
+            shelly_attr: temp
+        online:
+            type: bool
+            shelly_id: ..:.
+            shelly_type: ..:.
+            shelly_attr: online
+        battery:
+            type: num
+            shelly_id: ..:.
+            shelly_type: ..:.
+            shelly_attr: battery
+        error:
+            type: num
+            shelly_id: ..:.
+            shelly_type: ..:.
+            shelly_attr: error
 
     shellyflood:
         name: WLAN Flutsensor, mit Temperaturmessung

--- a/shelly/plugin.yaml
+++ b/shelly/plugin.yaml
@@ -40,6 +40,7 @@ item_attributes:
             - shellyswitch25
             - shelly4pro
             - shellyht
+            - shellyflood
         description:
             de: "Typ des Shelly Devices (z.B. Shellyplug, Shellyplug-s, Shelly1/pm, Shelly2, Shelly2.5, Shelly4Pro)"
             en: "Type of Shelly device (e.g. Shellyplug, Shellyplug-s. Shelly1/pm, Shelly2, Shelly2.5, Shelly4Pro)"
@@ -56,6 +57,8 @@ item_attributes:
             - temp_f
             - humidity
             - battery
+            - flood
+            - error
         description:
             de: "Zu lesendes/schreibendes Attribut des Shelly Devices. Achtung: Nicht jedes Attribut ist auf allen Device-Typen vorhanden."
             en: "Attribute of Shelly devcie that shall be read/written. Note: Not every attribute is available on all device types"
@@ -126,6 +129,33 @@ item_structs:
             shelly_id: ..:.
             shelly_type: ..:.
             shelly_attr: online
+        battery:
+            type: num
+            shelly_id: ..:.
+            shelly_type: ..:.
+            shelly_attr: battery
+
+    shellyflood:
+        name: WLAN Flutsensor, mit Temperaturmessung
+        type: bool
+        shelly_type: shellyflood
+        shelly_attr: flood
+
+        online:
+            type: bool
+            shelly_id: ..:.
+            shelly_type: ..:.
+            shelly_attr: online
+        temp:
+            type: num
+            shelly_id: ..:.
+            shelly_type: ..:.
+            shelly_attr: temp
+        error:
+            type: num
+            shelly_id: ..:.
+            shelly_type: ..:.
+            shelly_attr: error
         battery:
             type: num
             shelly_id: ..:.

--- a/shelly/plugin.yaml
+++ b/shelly/plugin.yaml
@@ -35,6 +35,7 @@ item_attributes:
         valid_list:
             - shellyplug
             - shellyplug-s
+            - shelly1
             - shelly1pm
             - shellyswitch
             - shellyswitch25

--- a/shelly/user_doc.rst
+++ b/shelly/user_doc.rst
@@ -10,7 +10,7 @@ shelly
 Das Plugin dienst zur Steuerung von Shelly Devices über MQTT. Zur Aktivierung von MQTT für die Shelly Devices bitte
 die Dokumentation des jeweiligen Devices zu Rate ziehen.
 
-Zurzeit wird Schalter (Relay) Funktion folgender Shelly Devices unterstützt:
+Zurzeit werden folgende Shelly Devices unterstützt:
 
 - Shelly1/pm
 - Shelly2
@@ -20,11 +20,17 @@ Zurzeit wird Schalter (Relay) Funktion folgender Shelly Devices unterstützt:
 - Shelly PlugS
 - Shelly H&T
 - Shelly Flood
+- Shelly Door/Window 2
 
 Es werden alle Relays eines Shelly Devices (bis zu 4) unterstützt. Weiterhin werden die folgenden
 Attribute/Parameter der Devices unterstützt, soweit die Devices selbst diese unterstützen:
 
 - humidity
+- state
+- tilt
+- vibration
+- lux
+- illumination
 - flood
 - battery
 - power

--- a/shelly/user_doc.rst
+++ b/shelly/user_doc.rst
@@ -12,16 +12,21 @@ die Dokumentation des jeweiligen Devices zu Rate ziehen.
 
 Zurzeit wird Schalter (Relay) Funktion folgender Shelly Devices unterstützt:
 
-- Shellyplug
-- Shellyplug-s
 - Shelly1/pm
 - Shelly2
 - Shelly2.5
 - Shelly4Pro
+- Shelly Plug
+- Shelly PlugS
+- Shelly H&T
+- Shelly Flood
 
 Es werden alle Relays eines Shelly Devices (bis zu 4) unterstützt. Weiterhin werden die folgenden
 Attribute/Parameter der Devices unterstützt, soweit die Devices selbst diese unterstützen:
 
+- humidity
+- flood
+- battery
 - power
 - energy
 - temperature
@@ -32,7 +37,7 @@ sowie der online-Status.
 
 .. attention::
 
-    Das Plugin kommuniziert über MQTT und benötigt das mqtt neues Modul, welches die Kommunikation mit dem MQTT Broker
+    Das Plugin kommuniziert über MQTT und benötigt das neue mqtt Modul, welches die Kommunikation mit dem MQTT Broker
     durchführt. Dieses Modul muß geladen und konfiguriert sein, damit das Plugin funktioniert.
 
 
@@ -92,7 +97,9 @@ Zur Vereinfachung der Einrichtung von Items sind für folgende Shelly Devices It
 
 - shellyplug
 - shellyplug_s
-
+- shellyht
+- shellyflood
+ 
 Unter Verwendung der entsprechenden Vorlage kann die Einrichtung einfach durch Angabe der shally_id des
 entsprechenden Devices erfolgen:
 


### PR DESCRIPTION
docs for shelly flood mqtt: https://shelly-api-docs.shelly.cloud/#shelly-flood-mqtt

the missing entry for shelly1 can also be read in the docs and is verified by me:

https://shelly-api-docs.shelly.cloud/#shelly1-1pm-mqtt

thats a view on my broker for the new flood device
![grafik](https://user-images.githubusercontent.com/226670/127399273-5077eb3c-b756-47d0-a80f-34b233f3a998.png)
