### PR TITLE
Super smooth dpt3 dimming for deconz (hue2)

### DIFF
--- a/hue2/plugin.yaml
+++ b/hue2/plugin.yaml
@@ -96,6 +96,12 @@ parameters:
 item_attributes:
     # Definition of item attributes defined by this plugin (enter 'item_attributes: NONE', if section should be empty)
 
+    dpt3_dim:
+        type: bool
+        description:
+            de: "Aktiviert DPT3 dimmen"
+            en: "Enabled DPT3 dimming"
+
     hue2_transitionTime:
         type: num
         description:
@@ -112,6 +118,13 @@ item_attributes:
           - group
           - scene
           - sensor
+
+    hue2_refence_light_id:
+        type: str
+        description:
+            de: "ID der des referenzwert gebenden Lichtes. Nur möglich wenn resource == group"
+            en: "ID of the light giving the reference value. Only possible if resource == group"
+
 
     hue2_id:
         type: str

--- a/hue2/plugin.yaml
+++ b/hue2/plugin.yaml
@@ -12,7 +12,7 @@ plugin:
 #    documentation: https://github.com/smarthomeNG/smarthome/wiki/CLI-Plugin        # url of documentation (wiki) page
     support: https://knx-user-forum.de/forum/supportforen/smarthome-py/1586861-support-thread-für-das-hue2-plugin
 
-    version: 2.1.0                  # Plugin version (must match the version specified in __init__.py)
+    version: 2.2.0                  # Plugin version (must match the version specified in __init__.py)
     sh_minversion: 1.8.2            # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
 #    py_minversion: 3.6             # minimum Python version to use for this plugin
@@ -24,6 +24,14 @@ plugin:
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml (enter 'parameters: NONE', if section should be empty)
+    default_transitionTime:
+        type: float
+        default: 0.4
+        valid_min: 0
+        description:
+            de: 'Zeit in sekunden welche die Leuchte benötigt um in einen neuen Zustand überzugehen'
+            en: 'Time in seconds required for the light to transition to a new state.'
+
     polltime_lights:
         type: int
         default: 5
@@ -88,6 +96,12 @@ parameters:
 item_attributes:
     # Definition of item attributes defined by this plugin (enter 'item_attributes: NONE', if section should be empty)
 
+    hue2_transitionTime:
+        type: num
+        description:
+            de: "Zeit für Übergang (in sec)"
+            en: "Time for transition (in sec)"
+
     hue2_resource:
         type: str
         description:
@@ -114,6 +128,7 @@ item_attributes:
           - ''
           - on
           - bri
+          - bri_inc
           - hue
           - sat
           - ct


### PR DESCRIPTION
Hello together,

today I have reconfigured all my lights in deconz, so that they are off after an power cycle (in our house there was a power outage last night and somehow it shitty that in the middle of the night almost all the lights in the house turned on). While doing that I noticed that Zigbee's "level control cluster" directly supports a relative dimming (with dimmstart and stop). After reading the code of deconz's REST API for a while, I found out that the function is implemented via the bri_inc attribute (0 means stop dimming).

I had to extend the HUE 2 plugin a bit (add bri_inc and hue2_transitionTime).

Furthermore I added the possibility to create a reference light for groups. If this is specified, the values are read from the reference light and not from the group action.
This was necessary because the values in the group action are not updated after the relative change.

The procedure for dimming corresponds in principle to the dimming in the old hue plugin:

Example:

```
KITCHEN:
    name: spots
    hue2_id: 7
    hue2_resource: group
    level_inc:
        type: num
        hue2_resource: ..:.
        hue2_id: ..:.
        hue2_function: bri_inc
        hue2_transitionTime: 6
        enforce_updates: 'true'
        dimdpt:
            type: list
            knx_dpt: 3
            knx_listen: 1/1/11
            dpt3_dim: true
            enforce_updates: 'true'
    level:
        type: num
        hue2_resource: ..:.
        hue2_id: ..:.
        hue2_function: bri
        hue2_transitionTime: 0.2
        hue2_refence_light_id: 3
```
          
I use Deconz, whether the whole thing also runs with the original HUE bridge I can not evaluate.
Maybe someone want to test this?


Limitations:
- Relative dimming range goes with me only from 1 to 254
- level/bri is set to 1 (dim down) or 254 (dim up) until the end of the dimming process, but then updated to the correct value.