### PR TITLE
smlx: convert EMH ED300L values to nicer format

### DIFF
--- a/smlx/__init__.py
+++ b/smlx/__init__.py
@@ -419,11 +419,12 @@ class Smlx(SmartPlugin):
                     # For a Holley DTZ541 with faulty Firmware remove the                ^[1] from this line ^.
 
                     # Convert some special OBIS values into nicer format
+                    # EMH ED300L: add additional OBIS codes
                     if entry['obis'] == '1-0:0.2.0*0':
                         entry['valueReal'] = entry['value'].decode()     # Firmware as UTF-8 string
-                    if entry['obis'] == '1-0:96.50.1*1':
+                    if entry['obis'] == '1-0:96.50.1*1' or entry['obis'] == '129-129:199.130.3*255':
                         entry['valueReal'] = entry['value'].decode()     # Manufacturer code as UTF-8 string
-                    if entry['obis'] == '1-0:96.1.0*255':
+                    if entry['obis'] == '1-0:96.1.0*255' or entry['obis'] == '1-0:0.0.9*255':
                         entry['valueReal'] = entry['value'].hex()        # ServerID (Seriel Number) as hex string as found on frontpanel
                     if entry['obis'] == '1-0:96.5.0*255':
                         entry['valueReal'] = bin(entry['value'] >> 8)    # Status as binary string, so not decoded into status bits as above


### PR DESCRIPTION
Hello together,

i was migrating from smarthomeng v1.5.1 to v1.9.1 and now using the smlx plugin. Before I have used the sml plugin.
I noticed WARNINGs about an incompatible string (manufactor + serial number) coming from the smlx plugin to the item.

`
2022-03-13 20:10:45 CET WARNING  item              plugins.smlx.Smlx Item Energie.Strom.Zaehler.Hersteller: value "b'EMH'" does not match type str. Via Sml None  --  (item.py:__update:1536)  
`

This pull request will fix this by expanding the obis codes for EMH ED300L smartmeter to convert the byte values to a nicer format.

This is tested on my installation and it works quite fine.

Happy to see this in a future release.

Kind Regards,
Julian
