### PR TITLE
hue2: fix multiple functions at once

### DIFF
--- a/hue2/__init__.py
+++ b/hue2/__init__.py
@@ -464,8 +464,9 @@ class Hue2(SmartPlugin):
                     plugin_item['item'](value, self.get_shortname(), src)
             if plugin_item['resource'] == 'group':
                 if not "hue2_refence_light_id" in plugin_item:
-                    value = self._get_group_item_value(plugin_item['id'], plugin_item['function'], plugin_item['item'].id())
-                    plugin_item['item'](value, self.get_shortname(), src)
+                    if plugin_item['function'] != 'dict':
+                        value = self._get_group_item_value(plugin_item['id'], plugin_item['function'], plugin_item['item'].id())
+                        plugin_item['item'](value, self.get_shortname(), src)
         return
 
 
@@ -494,17 +495,18 @@ class Hue2(SmartPlugin):
             src = None
         for pi in self.plugin_items:
             plugin_item = self.plugin_items[pi]
-            if plugin_item['resource'] == 'light':
-                value = self._get_light_item_value(plugin_item['id'], plugin_item['function'], plugin_item['item'].id())
-                if value is not None:
-                    plugin_item['item'](value, self.get_shortname(), src)
-
-            if plugin_item['resource'] == 'group':
-                if "hue2_refence_light_id" in plugin_item:
-                    reference_light_id = plugin_item["hue2_refence_light_id"]
-                    value = self._get_light_item_value(reference_light_id, plugin_item['function'], plugin_item['item'].id())
+            if plugin_item['function'] != 'dict':
+                if plugin_item['resource'] == 'light':
+                    value = self._get_light_item_value(plugin_item['id'], plugin_item['function'], plugin_item['item'].id())
                     if value is not None:
                         plugin_item['item'](value, self.get_shortname(), src)
+
+                if plugin_item['resource'] == 'group':
+                    if "hue2_refence_light_id" in plugin_item:
+                        reference_light_id = plugin_item["hue2_refence_light_id"]
+                        value = self._get_light_item_value(reference_light_id, plugin_item['function'], plugin_item['item'].id())
+                        if value is not None:
+                            plugin_item['item'](value, self.get_shortname(), src)
 
         return
 


### PR DESCRIPTION
Allows direct routing of multipe options to the qhue library. This makes it possible to simultaneously change e.g. brightness and color or turn on a lamp with a certain color or brightness.
The advantage of the simultaneous change is a very nice even fading between the states.

Since the dictionary is passed directly to the qhue library, which generates the API requests dynamically from the function call, all functions from the hue-api are supported.

Also e.g..  "effect", "colormode", "alert", "transitiontime".

See hue api:

http://www.burgestrand.se/hue-api/api/lights/
https://developers.meethue.com/develop/hue-api-v2/

Example:
```
{
        "on": True,
        "transitiontime": 10,
        "bri": 255,
        "ct": 370
}
```