### PR TITLE
modbus_tcp: keep connection open and use locking to ensure thread safety

### DIFF
--- a/modbus_tcp/__init__.py
+++ b/modbus_tcp/__init__.py
@@ -26,6 +26,7 @@
 from lib.model.smartplugin import *
 from lib.item import Items
 from datetime import datetime
+import threading
 
 from .webif import WebInterface
 
@@ -71,8 +72,10 @@ class modbus_tcp(SmartPlugin):
         self.connected = False
         
         self._Mclient = ModbusTcpClient(self._host, port=self._port)
+        self.lock = threading.Lock()
         
         self.init_webinterface(WebInterface)
+
         
         return
 
@@ -174,43 +177,47 @@ class modbus_tcp(SmartPlugin):
         changes on it's own, but has to be polled to get the actual status.
         It is called by the scheduler which is set within run() method.
         """
-        try:
-            if self._Mclient.connect():
-                self.logger.info("connected to {0}".format(str(self._Mclient)))
-                self.connected = True
-            else:
-                self.logger.error("could not connect to {0}:{1}".format(self._host, self._port))
+
+        with self.lock:
+            try:
+                if self._Mclient.connect():
+                    self.logger.info("connected to {0}".format(str(self._Mclient)))
+                    self.connected = True
+                else:
+                    self.logger.error("could not connect to {0}:{1}".format(self._host, self._port))
+                    self.connected = False
+                    return
+
+            except Exception as e:
+                self.logger.error("connection expection: {0} {1}".format(str(self._Mclient), e))
                 self.connected = False
                 return
-                
-        except Exception as e:
-            self.logger.error("connection expection: {0} {1}".format(str(self._Mclient), e))
-            self.connected = False
-            return
-            
+
+
         startTime = datetime.now()
         regCount = 0
         try:
             for reg, regPara in self._regToRead.items():
-                regAddr = regPara['regAddr']
-                value = self.__read_Registers(regPara)
-                #self.logger.debug("value readed: {0} type: {1}".format(value, type(value)))
-                if value is not None:
-                    item = regPara['item']
-                    if regPara['factor'] != 1:
-                        value = value * regPara['factor']
-                        #self.logger.debug("value {0} multiply by: {1}".format(value, regPara['factor']))
-                    item(value, self.get_fullname())
-                    regCount+=1
-                    
-                    if 'read_dt' in regPara:
-                        regPara['last_read_dt'] = regPara['read_dt']
-                    
-                    if 'value' in regPara:
-                        regPara['last_value'] = regPara['value']
-                    
-                    regPara['read_dt'] = datetime.now()
-                    regPara['value'] = value
+                with self.lock:
+                    regAddr = regPara['regAddr']
+                    value = self.__read_Registers(regPara)
+                    #self.logger.debug("value readed: {0} type: {1}".format(value, type(value)))
+                    if value is not None:
+                        item = regPara['item']
+                        if regPara['factor'] != 1:
+                            value = value * regPara['factor']
+                            #self.logger.debug("value {0} multiply by: {1}".format(value, regPara['factor']))
+                        item(value, self.get_fullname())
+                        regCount+=1
+
+                        if 'read_dt' in regPara:
+                            regPara['last_read_dt'] = regPara['read_dt']
+
+                        if 'value' in regPara:
+                            regPara['last_value'] = regPara['value']
+
+                        regPara['read_dt'] = datetime.now()
+                        regPara['value'] = value
             endTime = datetime.now()
             duration = endTime - startTime
             if regCount > 0:
@@ -219,9 +226,6 @@ class modbus_tcp(SmartPlugin):
             self.logger.debug("poll_device: {0} register readed requed-time: {1}".format(regCount, duration))
         except Exception as e:
             self.logger.error("something went wrong in the poll_device function: {0}".format(e))
-        finally:
-            self._Mclient.close()
-            #self.connected = False
         
      # called each time an item changes.
     def update_item(self, item, caller=None, source=None, dest=None):
@@ -273,30 +277,29 @@ class modbus_tcp(SmartPlugin):
             reg += '.'
             reg += str(slaveUnit)
             if reg in self._regToWrite:
-                regPara = self._regToWrite[reg]
-                self.logger.debug('update_item:{0} value:{1} regToWrite:{2}'.format(item, item(), reg))
-                try:
-                    if self._Mclient.connect():
-                        self.logger.info("connected to {0}".format(str(self._Mclient)))
-                        self.connected = True
-                    else:
-                        self.logger.error("could not connect to {0}:{1}".format(self._host, self._port))
+                with self.lock:
+                    regPara = self._regToWrite[reg]
+                    self.logger.debug('update_item:{0} value:{1} regToWrite:{2}'.format(item, item(), reg))
+                    try:
+                        if self._Mclient.connect():
+                            self.logger.info("connected to {0}".format(str(self._Mclient)))
+                            self.connected = True
+                        else:
+                            self.logger.error("could not connect to {0}:{1}".format(self._host, self._port))
+                            self.connected = False
+                            return
+
+                    except Exception as e:
+                        self.logger.error("connection expection: {0} {1}".format(str(self._Mclient), e))
                         self.connected = False
                         return
-                        
-                except Exception as e:
-                    self.logger.error("connection expection: {0} {1}".format(str(self._Mclient), e))
-                    self.connected = False
-                    return
-                    
-                startTime = datetime.now()
-                regCount = 0
-                try:
-                    self.__write_Registers(regPara, item())
-                except Exception as e:
-                    self.logger.error("something went wrong in the __write_Registers function: {0}".format(e))
-                finally:
-                    self._Mclient.close()
+
+                    startTime = datetime.now()
+                    regCount = 0
+                    try:
+                        self.__write_Registers(regPara, item())
+                    except Exception as e:
+                        self.logger.error("something went wrong in the __write_Registers function: {0}".format(e))
                 
     def __write_Registers(self, regPara, value):
         objectType = regPara['objectType']
@@ -323,7 +326,7 @@ class modbus_tcp(SmartPlugin):
             value = value * (1/regPara['factor'])
         
         self.logger.debug("write {0} to {1}.{2}.{3} (address.slaveUnit) dataType:{4}".format(value, objectType, address, slaveUnit, dataTypeStr))
-        builder = BinaryPayloadBuilder(byteorder=bo,wordorder=wo)
+        builder = BinaryPayloadBuilder(byteorder=bo, wordorder=wo)
         
         if dataType.lower() == 'uint':
             if bits == 16:
@@ -333,7 +336,7 @@ class modbus_tcp(SmartPlugin):
             elif bits == 64:
                 builder.add_64bit_uint(int(value))
             else:
-                self.logger.error("Number of bits or datatype not supportet : {0}".format(typeStr))
+                self.logger.error("Number of bits or datatype not supported : {0}".format(typeStr))
         elif dataType.lower() == 'int':
             if bits == 16:
                 builder.add_16bit_int(int(value))
@@ -342,14 +345,14 @@ class modbus_tcp(SmartPlugin):
             elif bits == 64:
                 builder.add_64bit_int(int(value))
             else:
-                self.logger.error("Number of bits or datatype not supportet : {0}".format(typeStr))
+                self.logger.error("Number of bits or datatype not supported : {0}".format(typeStr))
         elif dataType.lower() == 'float':
             if bits == 32:
                  builder.add_32bit_float(value)
             if bits == 64:
                  builder.add_64bit_float(value)
             else:
-                self.logger.error("Number of bits or datatype not supportet : {0}".format(typeStr))
+                self.logger.error("Number of bits or datatype not supported : {0}".format(typeStr))
         elif dataType.lower() == 'string':
             builder.add_string(value)
         elif dataType.lower() == 'bit':
@@ -363,7 +366,7 @@ class modbus_tcp(SmartPlugin):
                 else:
                     self.logger.error("Value is not a bitstring: {0}".format(value))
         else:
-            self.logger.error("Number of bits or datatype not supportet : {0}".format(typeStr))
+            self.logger.error("Number of bits or datatype not supported : {0}".format(typeStr))
             return None
         
         if objectType == 'Coil':
@@ -460,7 +463,7 @@ class modbus_tcp(SmartPlugin):
             elif bits == 64:
                 return decoder.decode_64bit_uint()
             else:
-                self.logger.error("Number of bits or datatype not supportet : {0}".format(typeStr))
+                self.logger.error("Number of bits or datatype not supported : {0}".format(typeStr))
         elif dataType.lower() == 'int':
             if bits == 16:
                 return decoder.decode_16bit_int()
@@ -469,14 +472,14 @@ class modbus_tcp(SmartPlugin):
             elif bits == 64:
                 return decoder.decode_64bit_int()
             else:
-                self.logger.error("Number of bits or datatype not supportet : {0}".format(typeStr))
+                self.logger.error("Number of bits or datatype not supported : {0}".format(typeStr))
         elif dataType.lower() == 'float':
             if bits == 32:
                 return decoder.decode_32bit_float()
             if bits == 64:
                 return decoder.decode_64bit_float()
             else:
-                self.logger.error("Number of bits or datatype not supportet : {0}".format(typeStr))
+                self.logger.error("Number of bits or datatype not supported : {0}".format(typeStr))
         elif dataType.lower() == 'string':
             # bei string: bits = bytes !! string16 -> 16Byte
             ret = decoder.decode_string(bits)
@@ -489,5 +492,5 @@ class modbus_tcp(SmartPlugin):
                 self.logger.debug("readed bits values: {0}".format(value.decode_bits()))
                 return decoder.decode_bits()
         else:
-            self.logger.error("Number of bits or datatype not supportet : {0}".format(typeStr))
+            self.logger.error("Number of bits or datatype not supported : {0}".format(typeStr))
         return None


### PR DESCRIPTION
Fixes race condition problems with high poll rates and speeds up plugging massively by keeping the TCP connection open.
Tcp connection is automatically re-established in case of error.
