### PR TITLE
Viessmann Plugin: Bugfix in method "_bytes2int"

### DIFF
--- a/viessmann/__init__.py
+++ b/viessmann/__init__.py
@@ -1255,7 +1255,7 @@ class Viessmann(SmartPlugin):
                     value = bool(value)
                 else:
                     value = int(value)
-                valuebytes = self._int2bytes(value, commandvaluebytes)
+                valuebytes = self._int2bytes(value, commandvaluebytes, byteorder='little')
                 self.logger.debug(f'Created value bytes for type {valuetype} as hexstring: {self._bytes2hexstring(valuebytes)} and as bytes: {valuebytes}')
             else:
                 self.logger.error(f'Type {valuetype} not definied for creating write command bytes')
@@ -1650,7 +1650,7 @@ class Viessmann(SmartPlugin):
             self.logger.error('No bytes received to calculate checksum')
         return checksum
 
-    def _int2bytes(self, value, length, signed=False):
+    def _int2bytes(self, value, length, signed=False, byteorder='big'):
         '''
         Convert value to bytearray with respect to defined length and sign format.
         Value exceeding limit set by length and sign will be truncated
@@ -1665,7 +1665,7 @@ class Viessmann(SmartPlugin):
         :rtype: bytearray
         '''
         value = value % (2 ** (length * 8))
-        return value.to_bytes(length, byteorder='big', signed=signed)
+        return value.to_bytes(length, byteorder=byteorder, signed=signed)
 
     def _bytes2int(self, rawbytes, signed):
         '''
@@ -1678,7 +1678,7 @@ class Viessmann(SmartPlugin):
         :return: Converted value
         :rtype: int
         '''
-        return int.from_bytes(rawbytes, byteorder='big', signed=signed)
+        return int.from_bytes(rawbytes, byteorder='little', signed=signed)
 
     def _bytes2hexstring(self, bytesvalue):
         '''

--- a/viessmann/__init__.py
+++ b/viessmann/__init__.py
@@ -64,7 +64,7 @@ class Viessmann(SmartPlugin):
     '''
     ALLOW_MULTIINSTANCE = False
 
-    PLUGIN_VERSION = '1.2.2'
+    PLUGIN_VERSION = '1.2.3'
 
 #
 # public methods
@@ -1678,7 +1678,7 @@ class Viessmann(SmartPlugin):
         :return: Converted value
         :rtype: int
         '''
-        return int.from_bytes(rawbytes, byteorder='little', signed=signed)
+        return int.from_bytes(rawbytes, byteorder='big', signed=signed)
 
     def _bytes2hexstring(self, bytesvalue):
         '''

--- a/viessmann/plugin.yaml
+++ b/viessmann/plugin.yaml
@@ -13,7 +13,7 @@ plugin:
     tester: sisamiwe, tcr82
     keywords: viessmann heating optolink
     state: ready                    # change to ready when done with development
-    version: 1.2.2                  # Plugin version
+    version: 1.2.3                  # Plugin version
     sh_minversion: 1.6.0            # minimum shNG version to use this plugin
     py_minversion: 3.6
     multi_instance: false           # plugin supports multi instance


### PR DESCRIPTION
In method "_bytes2int" wrong bytorder has been used