### PR TITLE
Update for compatibility to pymodbus version >= 3.0.0

### DIFF
--- a/kostalmodbus/README.md
+++ b/kostalmodbus/README.md
@@ -27,7 +27,7 @@ This plugin connects your Kostal inverter (https://www.kostal-solar-electric.com
 | PLENTICORE plus 5.5 | yes          | no      |
 | PLENTICORE plus 7.0 | yes          | yes     |
 | PLENTICORE plus 8.5 | yes          | yes     |
-| PLENTICORE plus 10  | yes          | no      |
+| PLENTICORE plus 10  | yes          | yes      |
 | PIKO IQ 4.2         | yes          | no      |
 | PIKO IQ 5.5         | yes          | no      |
 | PIKO IQ 7.0         | yes          | no      |

--- a/kostalmodbus/inverter.py
+++ b/kostalmodbus/inverter.py
@@ -7,7 +7,7 @@ import logging
 import pymodbus
 
 from lib.model.smartplugin import *
-from pymodbus.client.sync import ModbusTcpClient
+from pymodbus.client import ModbusTcpClient
 from pymodbus.payload import BinaryPayloadDecoder
 from pymodbus.constants import Endian
 
@@ -43,27 +43,27 @@ class Inverter:
         return self.registers
 
     def __read_float(self, adr_dec):
-        result = self.client.read_holding_registers(adr_dec, 2, unit=71)
+        result = self.client.read_holding_registers(adr_dec, 2, slave=71)
         float_value = BinaryPayloadDecoder.fromRegisters(result.registers,byteorder=Endian.Big,wordorder=Endian.Little)
         return round(float_value.decode_32bit_float(), 2)
 
     def __read_u16(self, adr_dec):
-        result = self.client.read_holding_registers(adr_dec, 1, unit=71)
+        result = self.client.read_holding_registers(adr_dec, 1, slave=71)
         u16_value = BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=Endian.Big,wordorder=Endian.Little)
         return u16_value.decode_16bit_uint()
 
     def __read_u16_2(self, adr_dec):
-        result = self.client.read_holding_registers(adr_dec, 2, unit=71)
+        result = self.client.read_holding_registers(adr_dec, 2, slave=71)
         u16_2_value = BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=Endian.Big,wordorder=Endian.Little)
         return u16_2_value.decode_16bit_uint()
 
     def __read_u32(self, adr_dec):
-        result = self.client.read_holding_registers(adr_dec, 2, unit=71)
+        result = self.client.read_holding_registers(adr_dec, 2, slave=71)
         u32_value = BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=Endian.Big,wordorder=Endian.Little)
         return u32_value.decode_32bit_uint()
 
     def __read_s16(self, adr_dec):
-        result = self.client.read_holding_registers(adr_dec, 1, unit=71)
+        result = self.client.read_holding_registers(adr_dec, 1, slave=71)
         s16_value = BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=Endian.Big,wordorder=Endian.Little)
         return s16_value.decode_16bit_uint()
 

--- a/kostalmodbus/plugin.yaml
+++ b/kostalmodbus/plugin.yaml
@@ -12,7 +12,7 @@ plugin:
     documentation:
     support:
 
-    version: 1.6.0                  # Plugin version
+    version: 1.6.1                  # Plugin version
     sh_minversion: 1.6              # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     py_minversion: 3.6              # minimum Python version to use this plugin

--- a/kostalmodbus/requirements.txt
+++ b/kostalmodbus/requirements.txt
@@ -1,1 +1,1 @@
-pymodbus >= 3.0.0
+pymodbus >= 3.0.0;python_version>='3.8'

--- a/kostalmodbus/requirements.txt
+++ b/kostalmodbus/requirements.txt
@@ -1,1 +1,1 @@
-pymodbus >= 2.3.0
+pymodbus >= 3.0.0

--- a/ksemmodbus/ksem.py
+++ b/ksemmodbus/ksem.py
@@ -7,7 +7,7 @@ import logging
 import pymodbus
 
 from lib.model.smartplugin import *
-from pymodbus.client.sync import ModbusTcpClient
+from pymodbus.client import ModbusTcpClient
 from pymodbus.payload import BinaryPayloadDecoder
 from pymodbus.constants import Endian
 
@@ -45,32 +45,32 @@ class Ksem:
         return self.registers
 
     def __read_float(self, adr_dec):
-        result = self.client.read_holding_registers(adr_dec, 2, unit=71)
+        result = self.client.read_holding_registers(adr_dec, 2, slave=71)
         float_value = BinaryPayloadDecoder.fromRegisters(result.registers,byteorder=Endian.Big,wordorder=Endian.Little)
         return round(float_value.decode_32bit_float(), 2)
 
     def __read_u16(self, adr_dec):
-        result = self.client.read_holding_registers(adr_dec, 1, unit=71)
+        result = self.client.read_holding_registers(adr_dec, 1, slave=71)
         u16_value = BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=Endian.Big,wordorder=Endian.Little)
         return u16_value.decode_16bit_uint()
 
     def __read_u16_2(self, adr_dec):
-        result = self.client.read_holding_registers(adr_dec, 2, unit=71)
+        result = self.client.read_holding_registers(adr_dec, 2, slave=71)
         u16_2_value = BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=Endian.Big,wordorder=Endian.Little)
         return u16_2_value.decode_16bit_uint()
 
     def __read_s16(self, adr_dec):
-        result = self.client.read_holding_registers(adr_dec, 1, unit=71)
+        result = self.client.read_holding_registers(adr_dec, 1, slave=71)
         s16_value = BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=Endian.Big,wordorder=Endian.Little)
         return s16_value.decode_16bit_uint()
 
     def __read_u32(self, adr_dec):
-        result = self.client.read_holding_registers(adr_dec, 2, unit=71)
+        result = self.client.read_holding_registers(adr_dec, 2, slave=71)
         u32_value = BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=Endian.Big, wordorder=Endian.Big)
         return round((u32_value.decode_32bit_uint() * 0.1), 2)
 
     def __read_u64(self, adr_dec):
-        result = self.client.read_holding_registers(adr_dec, 4, unit=71)
+        result = self.client.read_holding_registers(adr_dec, 4, slave=71)
         u64_value = BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=Endian.Big, wordorder=Endian.Big)
         return round((u64_value.decode_64bit_uint() * 0.0001),2)
 

--- a/ksemmodbus/plugin.yaml
+++ b/ksemmodbus/plugin.yaml
@@ -11,7 +11,7 @@ plugin:
     documentation:
     support:
 
-    version: 1.6.0                  # Plugin version
+    version: 1.6.1                  # Plugin version
     sh_minversion: 1.6              # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False           # plugin supports multi instance

--- a/ksemmodbus/requirements.txt
+++ b/ksemmodbus/requirements.txt
@@ -1,1 +1,1 @@
-pymodbus >= 3.0.0
+pymodbus >= 3.0.0;python_version>='3.8'

--- a/ksemmodbus/requirements.txt
+++ b/ksemmodbus/requirements.txt
@@ -1,1 +1,1 @@
-pymodbus >= 2.3.0
+pymodbus >= 3.0.0


### PR DESCRIPTION
Pymodbus:
Version [2.5.3](https://github.com/riptideio/pymodbus/releases/tag/v2.5.3) is the last 2.x release (Supports python 2.7.x - 3.7).

Version [3.0.2](https://github.com/riptideio/pymodbus/releases/tag/v3.0.2) is the current release (Supports Python >=3.8).