### PR TITLE
hue2 plugin: some fixes (discovery and typos) and enhancements (any_on state for groups)

### DIFF
--- a/hue2/__init__.py
+++ b/hue2/__init__.py
@@ -199,9 +199,9 @@ class Hue2(SmartPlugin):
             conf_data['id'] = self.get_iattr_value(item.conf, 'hue2_id')
             conf_data['resource'] = self.get_iattr_value(item.conf, 'hue2_resource')
             conf_data['function'] = self.get_iattr_value(item.conf, 'hue2_function')
-            if self.has_iattr(item.conf, 'hue2_refence_light_id'):
+            if self.has_iattr(item.conf, 'hue2_reference_light_id'):
                 if conf_data['resource'] == "group":
-                    conf_data['hue2_refence_light_id'] = self.get_iattr_value(item.conf, 'hue2_refence_light_id')
+                    conf_data['hue2_reference_light_id'] = self.get_iattr_value(item.conf, 'hue2_reference_light_id')
 
             conf_data['item'] = item
             self.plugin_items[item.path()] = conf_data
@@ -463,7 +463,7 @@ class Hue2(SmartPlugin):
                 if value is not None:
                     plugin_item['item'](value, self.get_shortname(), src)
             if plugin_item['resource'] == 'group':
-                if not "hue2_refence_light_id" in plugin_item:
+                if not "hue2_reference_light_id" in plugin_item:
                     if plugin_item['function'] != 'dict':
                         value = self._get_group_item_value(plugin_item['id'], plugin_item['function'], plugin_item['item'].id())
                         plugin_item['item'](value, self.get_shortname(), src)
@@ -502,8 +502,8 @@ class Hue2(SmartPlugin):
                         plugin_item['item'](value, self.get_shortname(), src)
 
                 if plugin_item['resource'] == 'group':
-                    if "hue2_refence_light_id" in plugin_item:
-                        reference_light_id = plugin_item["hue2_refence_light_id"]
+                    if "hue2_reference_light_id" in plugin_item:
+                        reference_light_id = plugin_item["hue2_reference_light_id"]
                         value = self._get_light_item_value(reference_light_id, plugin_item['function'], plugin_item['item'].id())
                         if value is not None:
                             plugin_item['item'](value, self.get_shortname(), src)

--- a/hue2/__init__.py
+++ b/hue2/__init__.py
@@ -545,7 +545,7 @@ class Hue2(SmartPlugin):
 
     def _get_light_item_value(self, light_id, function, item_path):
         """
-        Update item that hat hue_resource == 'light'
+        Update item that has hue_resource == 'light'
         :param id:
         :param function:
         :return:
@@ -579,7 +579,7 @@ class Hue2(SmartPlugin):
 
     def _get_group_item_value(self, group_id, function, item_path):
         """
-        Update item that hat hue_resource == 'light'
+        Update item that has hue_resource == 'group'
         :param id:
         :param function:
         :return:
@@ -602,7 +602,7 @@ class Hue2(SmartPlugin):
 
     def _get_scene_item_value(self, scene_id, function, item_path):
         """
-        Update item that hat hue_resource == 'light'
+        Update item that has hue_resource == 'scene'
         :param id:
         :param function:
         :return:

--- a/hue2/discover_bridges.py
+++ b/hue2/discover_bridges.py
@@ -158,7 +158,7 @@ def discover_via_upnp():
     ssdp_list = ssdp_discover("ssdp:all", timeout=10)
     t2 = datetime.now()
 
-    devices = [u for u in ssdp_list if 'IpBridge' in u.server]
+    devices = [u for u in ssdp_list if (u.server is not None and 'IpBridge' in u.server)]
     for d in devices:
         ip_port = d.location.split('/')[2]
         ip = ip_port.split(':')[0]

--- a/hue2/plugin.yaml
+++ b/hue2/plugin.yaml
@@ -119,7 +119,7 @@ item_attributes:
           - scene
           - sensor
 
-    hue2_refence_light_id:
+    hue2_reference_light_id:
         type: str
         description:
             de: "ID der des referenzwert gebenden Lichtes. Nur möglich wenn resource == group"


### PR DESCRIPTION
- When SSDP Discovery gets a response with an empty server description, the bridge discovery crashes and no bridge can be found

`/usr/local/smarthome/plugins/hue2# python3 discover_bridges.py
++++++++++++++++++++++ discover_bridges (1)
  http://192.168.178.122:49000/fboxdesc.xml ==> FRITZ!Repeater 1200 UPnP/1.0 AVM FRITZ!Repeater 1200 172.07.29
  http://192.168.178.1:49000/MediaServerDevDesc.xml ==> FRITZ!Box 7590 UPnP/1.0 AVM FRITZ!Box 7590 154.07.50
  http://192.168.178.1:49000/avmnexusdesc.xml ==> FRITZ!Box 7590 UPnP/1.0 AVM FRITZ!Box 7590 154.07.50
  http://192.168.178.1:49000/fboxdesc.xml ==> FRITZ!Box 7590 UPnP/1.0 AVM FRITZ!Box 7590 154.07.50
  http://192.168.178.84:80/plugin/discovery/discovery.xml ==> None
Traceback (most recent call last):
  File "/usr/local/smarthome/plugins/hue2/discover_bridges.py", line 301, in <module>
    my_discovered_bridges = discover_bridges(upnp=True, httponly=True)
  File "/usr/local/smarthome/plugins/hue2/discover_bridges.py", line 235, in discover_bridges
    discover_bridges_by_method(mdns=False, upnp=True, broker=False, httponly=httponly)
  File "/usr/local/smarthome/plugins/hue2/discover_bridges.py", line 218, in discover_bridges_by_method
    discover_via_upnp()
  File "/usr/local/smarthome/plugins/hue2/discover_bridges.py", line 164, in discover_via_upnp
    if 'IpBridge' in device.server:
TypeError: argument of type 'NoneType' is not iterable`

- Also fix nasty typo with "hue_refence_light_id" and some more

- implement On-State retrieval for groups through parsing groups "any_on" state. Still possible to use "hue2_reference_light_id" instead to keep old behaviour (takes predecence). So normal use would either be not to define "hue2_reference_light_id" on groups at all (results in meaningful on/off state) or use "hue2_reference_light_id" only on stuff light brightness and saturation. And, if you are really determined, use "hue2_reference_light_id" also on "on" function..