### PR TITLE
Adapt handling of knx_Listen

### DIFF
--- a/knx/webif/templates/index.html
+++ b/knx/webif/templates/index.html
@@ -208,7 +208,11 @@ $(document).ready(
 						knx_init: {{ item.conf['knx_init'] }}<br>
 					{% endif %}
 					{% if 'knx_listen' in item.conf %}
-						knx_listen: {{ item.conf['knx_listen'] }}<br>
+						{% if item.conf['knx_listen']|length == 1 %}
+                            				knx_listen: {{ item.conf['knx_listen'][0] }}<br>
+                        			{% else %}
+                            				knx_listen: {{ item.conf['knx_listen'] }}<br>
+                        			{% endif %}
 					{% endif %}
 					</td>
 					{% if item.conf['knx_send']|length == 1 %}


### PR DESCRIPTION
If knx_listen just contains 1 entry, it will be shown directly. 
If knx_listen contains more than 1 entry, it will be shown as list.