### PR TITLE
Workflow: Fix unittest for forked repos

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -42,15 +42,19 @@ jobs:
           echo github.pull_request.base.ref  '${{ github.pull_request.base.ref }}'
           echo steps.extract_branch.outputs.branch '${{ steps.extract_branch.outputs.branch }}'
 
-      - name: Checkout core from branch '${{ steps.extract_branch.outputs.branch }}' (for push)
-        if: github.event_name != 'pull_request'
+      - name: Check if branch '${{ steps.extract_branch.outputs.branch }}' exists in smarthomeNG/smarthome
+        run: echo "code=$(git ls-remote --exit-code --heads https://github.com/smarthomeNG/smarthome ${{ steps.extract_branch.outputs.branch }} > /dev/null; echo $? )" >>$GITHUB_OUTPUT
+        id: shng_branch_check
+
+      - name: Checkout core from branch '${{ steps.extract_branch.outputs.branch }}' (for push on known smarthomeNG/smarthome branch)
+        if: github.event_name != 'pull_request' && steps.shng_branch_check.outputs.code == '0'
         uses: actions/checkout@v3
         with:
           repository: smarthomeNG/smarthome
           ref: ${{ steps.extract_branch.outputs.branch }}
 
-      - name: Checkout core from branch 'develop' (for pull request)
-        if: github.event_name == 'pull_request'
+      - name: Checkout core from branch 'develop' (for pull request or push on unknown smarthomeNG/smarthome branch)
+        if: github.event_name == 'pull_request' || steps.shng_branch_check.outputs.code == '2'
         uses: actions/checkout@v3
         with:
           repository: smarthomeNG/smarthome
@@ -59,7 +63,7 @@ jobs:
       - name: Checkout plugins from branch '${{steps.extract_branch.outputs.branch}}'
         uses: actions/checkout@v3
         with:
-          repository: smarthomeNG/plugins
+          repository: ${{ github.repository_owner }}/plugins
           ref: ${{steps.extract_branch.outputs.branch}}
           path: plugins
 


### PR DESCRIPTION
The unittests in new branches (for example this workflow) of forks from smarthomeNG/plugins fail always on `Checkout core from branch 'workflow' (for push)` because they are trying to checkout the actual (workflow) branch from the smarthomeNG/smarthome repo.
This branch obviously does not exist on most of the plugin development cases. But sometimes it could also be useful, for example if someone is working, lets say, on plugins/smartvisu and there is a associated development on the smarthome websocket module with the same branch name.
So instead of removing this workflow step, I added a check if such a branch exists in smarthomeNG/smarthome, if its there it gets checked out, if not the develop branch gets checked out.

And in the following steps instead of checking out the smarthome/plugins repo, I need to check out the actual repo owners /plugins.