### PR TITLE
AVM Plugin: Bugfix and Extension of 'get_hosts'

### DIFF
--- a/avm/plugin.yaml
+++ b/avm/plugin.yaml
@@ -12,7 +12,7 @@ plugin:
     documentation: http://smarthomeng.de/user/plugins/avm/user_doc.html
     support: https://knx-user-forum.de/forum/supportforen/smarthome-py/934835-avm-plugin
 
-    version: 2.0.4                  # Plugin version (must match the version specified in __init__.py)
+    version: 2.0.5                  # Plugin version (must match the version specified in __init__.py)
     sh_minversion: 1.8              # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
 #    py_minversion: 3.6             # minimum Python version to use for this plugin
@@ -1210,7 +1210,28 @@ plugin_functions:
             de: Liefert Informationen aller Hosts als Dictionary
             en: Lists information of all hosts as dict
         parameters:
-      # This function has no parameters
+            only_active:
+                type: bool
+                description:
+                    de: True, wenn nur aktuell aktive Hosts zurückgegeben werden sollen.
+                    en: True, if only active hosts shall be returned.
+
+    get_hosts_list:
+        type: list(dict)
+        description:
+            de: Liefert Informationen gefilterte Information zu den verbundenen Hosts als Array
+            en: Lists information of filtered hosts as array
+        parameters:
+            identifier_list:
+                type: list
+                description:
+                    de: "Liste von Identifiers des Hosts, die zurückgegeben werden sollen; (möglich: 'Index', 'IPAddress', 'MACAddress', 'HostName', 'FriendyName')"
+                    en: "list of identifiers of host, which will be returned; (valid: 'Index', 'IPAddress', 'MACAddress', 'HostName', 'FriendyName')"
+            filter_dict:
+                type: dict
+                description:
+                    de: "Dict von Filtern, für welche die Host-Identifier zurückgegeben werden sollen (bspw: filter={'Active': False} gibt alle nicht-aktiven Host zurück)"
+                    en: "dict of filters, for which hosts (identifiers) will be returned (e.g. filter={'Active': False} will return all non-active hosts)"
 
 logic_parameters: NONE
     # Definition of logic parameters defined by this plugin (enter 'logic_parameters: NONE', if section should be empty)

--- a/avm/user_doc.rst
+++ b/avm/user_doc.rst
@@ -243,6 +243,61 @@ Beispiel einer Logik, die die Host von 3 verbundenen Geräten in eine Liste zusa
     string += '</ul>'
     sh.avm.devices.device_list(string)
 
+get_hosts_list
+~~~~~~~~~~~~~~
+
+Ermittelt ein Array mit (gefilterten) Informationen der verbundenen Hosts. Dabei wird die die Abfrage der "Host List Contents" verwendet.
+Der Vorteil gegenüber "get_hosts" liegt in der deutlich schnelleren Abfrage.
+
+In Abfrage der Hosts liefert folgenden Werte:
+
+  - 'Index'
+  - 'IPAddress'
+  - 'MACAddress'
+  - 'Active'
+  - 'HostName'
+  - 'InterfaceType'
+  - 'Port'
+  - 'Speed'
+  - 'UpdateAvailable'
+  - 'UpdateSuccessful'
+  - 'InfoURL'
+  - 'MACAddressList'
+  - 'Model'
+  - 'URL'
+  - 'Guest'
+  - 'RequestClient'
+  - 'VPN'
+  - 'WANAccess'
+  - 'Disallow'
+  - 'IsMeshable'
+  - 'Priority'
+  - 'FriendlyName'
+  - 'FriendlyNameIsWriteable'
+
+Auf all diese Werte kann mit dem Parameter "filter_dict" gefiltert werden. Dabei können auch mehrere Filter gesetzt werden.
+
+Das folgende Beispiel liefert alle Informationen zu den aktiven Hosts zurück:
+
+.. code-block:: python
+
+    hosts = sh.fritzbox_7490.get_hosts_list(filter_dict={'Active': True})
+
+Das folgende Beispiel liefer alle Informationen zu den aktiven Hosts zurück, bei den ein Update vorliegt:
+
+.. code-block:: python
+
+    hosts = sh.fritzbox_7490.get_hosts_list(filter_dict={'Active': True, 'UpdateAvailable': True})
+
+Des Weiteren können über den Parameter "identifier_list" die Identifier des Hosts festgelegt werden, die zurückgegeben werden sollen.
+Möglich sind: 'index', 'ipaddress', 'macaddress', 'hostname', 'friendlyname'
+
+Das folgende Beispiel liefer 'IPAddress' und 'MACAddress' zu den aktiven Hosts zurück, bei den ein Update vorliegt:
+
+.. code-block:: python
+
+    hosts = sh.fritzbox_7490.get_hosts_list(identifier_list=['ipaddress', 'macaddress'], filter_dict={'Active': True, 'UpdateAvailable': True})
+
 get_phone_name
 ~~~~~~~~~~~~~~
 Gibt den Namen eines Telefons an einem Index zurück. Der zurückgegebene Wert kann in 'set_call_origin' verwendet werden.


### PR DESCRIPTION
- Bump to 2.0.5
- NEW get_hosts_dict: enable "only_active"
- NEW get_hosts_list: returns list for (filtered host); provides more flexibility and much quicker results as get_hosts
- BUGFIX is_host_active
- BUGFIX get_hosts
- UPDATE get_hosts_dict
- NEW get_hosts_count: Enable only_active
- UPDATE plugin.yaml
- UPDATE user_doc.rst