### PR TITLE
Support RFC2217 connections for enocean plugin

### DIFF
--- a/enocean/plugin.yaml
+++ b/enocean/plugin.yaml
@@ -16,7 +16,7 @@ plugin:
     # url of the support thread
     support: https://knx-user-forum.de/forum/supportforen/smarthome-py/26542-featurewunsch-enocean-plugin/page13
 
-    version: 1.3.9                 # Plugin version
+    version: 1.3.10                 # Plugin version
     sh_minversion: 1.3             # minimum shNG version to use this plugin
     #sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False          # plugin supports multi instance
@@ -29,8 +29,8 @@ parameters:
         type: str
         default: /dev/ttyAMA0
         description:
-            de: 'Name der Schnittstelle, an der sich der EnOcean Adapter befindet'
-            en: 'name of the port where the EnOcean adapter is plugged in'
+            de: 'Name der Schnittstelle, an der sich der EnOcean Adapter befindet (als Linux-Handle oder RFC2217-URL)'
+            en: 'name of the port where the EnOcean adapter is plugged in (as a linux file handle or RFC2217 URL)'
 
     tx_id:
         type: str

--- a/enocean/user_doc.rst
+++ b/enocean/user_doc.rst
@@ -41,6 +41,20 @@ Hierzu folgendes in der Linux Konsole ausführen:
 Aktoren, Schalter oder Stellglieder, die vom Enocean plugin gesteuert werden sollen, müssen vorher einmalig angelert werden. Der Anlernvorgang wird unten im Kaptiel Webinterface beschrieben.
 Für das Auslesen von Statusinfromationen von Enocean Sensoren ist kein Anlernvorgang nötig.
 
+Verwendung via IP
+-------------
+
+Alternativ kann eines der oben erwähnten Serial-Geräte auch über das Netzwerk freigegeben werden und per RFC2217 eingebunden werden. Die Freigabe erfolgt auf dem Host mithilfe von `ser2net <https://linux.die.net/man/8/ser2net>`. Eine beispielhafte Konfiguration (ser2net.yaml) könnte so aussehen:
+
+.. code-block:: yaml
+
+    connection: &tS4telnet
+        accepter: telnet(rfc2217),tcp,<PORT>
+        connector: serialdev,
+                   <DEVICE>,
+                   57600n81,local
+
+Für <PORT> und <DEVICE> sind die entsprechenden Werte einzufügen.
 
 Konfiguration
 =============
@@ -54,6 +68,8 @@ plugin.yaml
 
 Hier wird der `serialport` zum Enocean Hardwareadapter angegeben werden.
 Unter Linux wird empfohlen, das entsprechende Linux Uart device über eine Udev-Regel auf einen Link zu mappen und diesen Link dann als `serialport` anzugeben.
+
+Soll ein Gerät über das Netzwerk angebunden werden, wird hier anstatt des Unix-Handles eine URL in folgender Form angegeben: ``rfc2217://<HOST>:<PORT>``.
 
 **tx_id**
 


### PR DESCRIPTION
This change is in reference to [this thread](https://knx-user-forum.de/forum/supportforen/smarthome-py/1872963-verlust-von-serial-device-bringt-enocean-und-smarthomeng-zum-absturz) at the KNX user forum. 

The `serial.Serial()` constructor from pyserial was replaced with `serial.serial_for_url()`, which supports both the traditional unix file handle (e.g. `/dev/ttyAMA0`) and RFC2217-compliant URLS (e.g.`rfc2217://<IP>:<PORT>`) interchangeably. 

Error handling was added to deal with connection breakdowns and reinitiate the connection. In case of a connection breakdown at transmission time, one attempt at retransmission will be made. Afterwards, the packet will be lost.

It's not clear to me if the run method will be restarted on successful reconnection after the loop has been broken (change made in commit c9c2538 ), so this might be a potential improvement for the future.