### PR TITLE
modbus updates

### DIFF
--- a/kostalmodbus/README.md
+++ b/kostalmodbus/README.md
@@ -1,24 +1,21 @@
 # Modbus Plugin for Kostal inverters
 
-#### Version 1.6.2
+#### Version 1.6.3
 
 This plugin connects your Kostal inverter (https://www.kostal-solar-electric.com/) via ModBus with SmarthomeNG.
 - read out all inverter data
 
+
 ## Change history
 
-- work with newer versions of pymodbus too
-
-### Changes Since version 1.x.x
-
-- No Changes so far
+- support for pymodbus 2 dropped
 
 
 ### Requirements needed software
 
-* Python > 3.5
+* Python >= 3.8
 * pip install pymodbus
-* SmarthomeNG >= 1.6.0
+* SmarthomeNG >= 1.8.0
 
 
 ### Supported Inverters

--- a/kostalmodbus/__init__.py
+++ b/kostalmodbus/__init__.py
@@ -28,7 +28,7 @@ from lib.model.smartplugin import *
 from .inverter import Inverter
 
 class Kostalmodbus(SmartPlugin):
-    PLUGIN_VERSION = '1.6.2'
+    PLUGIN_VERSION = '1.6.3'
     inverter = 'None'
     _items = []
 

--- a/kostalmodbus/inverter.py
+++ b/kostalmodbus/inverter.py
@@ -8,17 +8,7 @@ import pymodbus
 
 from lib.model.smartplugin import *
 
-# pymodbus library from https://github.com/riptideio/pymodbus
-from pymodbus.version import version
-pymodbus_baseversion = int(version.short().split('.')[0])
-
-if pymodbus_baseversion > 2:
-    # for newer versions of pymodbus
-    from pymodbus.client.tcp import ModbusTcpClient
-else:
-    # for older versions of pymodbus
-    from pymodbus.client.sync import ModbusTcpClient
-
+from pymodbus.client.tcp import ModbusTcpClient
 from pymodbus.payload import BinaryPayloadDecoder
 from pymodbus.constants import Endian
 
@@ -60,67 +50,44 @@ class Inverter:
         return self.registers
 
     def __read_float(self, adr_dec):
-        if pymodbus_baseversion > 2:
-            result = self.client.read_holding_registers(adr_dec, 2, slave=71)
-        else:
-            result = self.client.read_holding_registers(adr_dec, 2, unit=71)
-        float_value = BinaryPayloadDecoder.fromRegisters(result.registers,byteorder=Endian.Big,wordorder=Endian.Little)
+        result = self.client.read_holding_registers(adr_dec, 2, slave=71)
+        float_value = BinaryPayloadDecoder.fromRegisters(result.registers,byteorder=Endian.BIG,wordorder=Endian.LITTLE)
         return round(float_value.decode_32bit_float(), 2)
 
     def __read_u16(self, adr_dec):
-        if pymodbus_baseversion > 2:
-            result = self.client.read_holding_registers(adr_dec, 1, slave=71)
-        else:
-            result = self.client.read_holding_registers(adr_dec, 1, unit=71)
-        u16_value = BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=Endian.Big,wordorder=Endian.Little)
+        result = self.client.read_holding_registers(adr_dec, 1, slave=71)
+
+        u16_value = BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=Endian.BIG,wordorder=Endian.LITTLE)
         return u16_value.decode_16bit_uint()
 
     def __read_u16_2(self, adr_dec):
-        if pymodbus_baseversion > 2:
-            result = self.client.read_holding_registers(adr_dec, 2, slave=71)
-        else:
-            result = self.client.read_holding_registers(adr_dec, 2, unit=71)
-        u16_2_value = BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=Endian.Big,wordorder=Endian.Little)
+        result = self.client.read_holding_registers(adr_dec, 2, slave=71)
+        u16_2_value = BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=Endian.BIG,wordorder=Endian.LITTLE)
         return u16_2_value.decode_16bit_uint()
 
     def __read_u32(self, adr_dec):
-        if pymodbus_baseversion > 2:
-            result = self.client.read_holding_registers(adr_dec, 2, slave=71)
-        else:
-            result = self.client.read_holding_registers(adr_dec, 2, unit=71)
-        u32_value = BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=Endian.Big,wordorder=Endian.Little)
+        result = self.client.read_holding_registers(adr_dec, 2, slave=71)
+        u32_value = BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=Endian.BIG,wordorder=Endian.LITTLE)
         return u32_value.decode_32bit_uint()
 
     def __read_s16(self, adr_dec):
-        if pymodbus_baseversion > 2:
-            result = self.client.read_holding_registers(adr_dec, 1, slave=71)
-        else:
-            result = self.client.read_holding_registers(adr_dec, 1, unit=71)
-        s16_value = BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=Endian.Big,wordorder=Endian.Little)
+        result = self.client.read_holding_registers(adr_dec, 1, slave=71)
+        s16_value = BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=Endian.BIG,wordorder=Endian.LITTLE)
         return s16_value.decode_16bit_uint()
         
     def __read_str08(self, adr_dec):
-        if pymodbus_baseversion > 2:
-            result = self.client.read_holding_registers(adr_dec, 8, slave=71)
-        else:
-            result = self.client.read_holding_registers(adr_dec, 8, unit=71)
-        str08_value = BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=Endian.Big,wordorder=Endian.Little)
+        result = self.client.read_holding_registers(adr_dec, 8, slave=71)
+        str08_value = BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=Endian.BIG,wordorder=Endian.LITTLE)
         return str08_value.decode_string(size=16).rstrip(b'\0').decode('utf-8')
         
     def __read_str16(self, adr_dec):
-        if pymodbus_baseversion > 2:
-            result = self.client.read_holding_registers(adr_dec, 16, slave=71)
-        else:
-            result = self.client.read_holding_registers(adr_dec, 16, unit=71)
-        str08_value = BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=Endian.Big,wordorder=Endian.Little)
+        result = self.client.read_holding_registers(adr_dec, 16, slave=71)
+        str08_value = BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=Endian.BIG,wordorder=Endian.LITTLE)
         return str08_value.decode_string(size=24).rstrip(b'\0').decode('utf-8')
         
     def __read_str32(self, adr_dec):
-        if pymodbus_baseversion > 2:
-            result = self.client.read_holding_registers(adr_dec, 32, slave=71)
-        else:
-            result = self.client.read_holding_registers(adr_dec, 32, unit=71)
-        str08_value = BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=Endian.Big,wordorder=Endian.Little)
+        result = self.client.read_holding_registers(adr_dec, 32, slave=71)
+        str08_value = BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=Endian.BIG,wordorder=Endian.LITTLE)
         return str08_value.decode_string(size=32).rstrip(b'\0').decode('utf-8')
 
     decRow = [30,32,34,36,54,56,100,104,106,108,110,112,114,116,118,120,122,124,144,150,152,154,156,

--- a/kostalmodbus/plugin.yaml
+++ b/kostalmodbus/plugin.yaml
@@ -5,17 +5,17 @@ plugin:
     description:
         de: 'Plugin zur Anbindung von einem Kostal Wechselrichter über Modbus an SmartHomeNG'
         en: 'Plugin to connect your Kostal inverter via modbus with SmartHomeNG'
-    maintainer: Thomas Hengsberg (thengsty)
+    maintainer: Thomas Hengsberg (thengsty), Cannon
     tester:
     state: develop                  # change to ready when done with development
 #    keywords: iot xyz
     documentation:
     support:
 
-    version: 1.6.2                  # Plugin version
-    sh_minversion: 1.6              # minimum shNG version to use this plugin
+    version: 1.6.3                  # Plugin version
+    sh_minversion: 1.8              # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
-    py_minversion: 3.6              # minimum Python version to use this plugin
+    py_minversion: 3.8              # minimum Python version to use this plugin
 #    py_maxversion:                 # maximum Python version to use this plugin (leave empty if latest)
     multi_instance: False           # plugin supports multi instance
     restartable: unknown

--- a/kostalmodbus/requirements.txt
+++ b/kostalmodbus/requirements.txt
@@ -1,2 +1,1 @@
-pymodbus>=2.3,<3.0;python_version<'3.8'
-pymodbus>=3.0.2;python_version>="3.8"
+pymodbus>=3.5.2;python_version>='3.8'

--- a/ksemmodbus/README.md
+++ b/ksemmodbus/README.md
@@ -1,24 +1,21 @@
 # Modbus Plugin for Kostal Smart Energy Meter
 
-#### Version 1.6.2
+#### Version 1.6.3
 
 This plugin connects your Kostal Smart Energy Meter (https://www.kostal-solar-electric.com/) via ModBus with SmarthomeNG.
 - read out all Smart Meter data
 
+
 ## Change history
 
-- work with newer versions of pymodbus too 
-
-### Changes Since version 1.x.x
-
-- No Changes so far
+- support for pymodbus 2 dropped
 
 
 ### Requirements needed software
 
-* Python > 3.5
+* Python >= 3.8
 * pip install pymodbus
-* SmarthomeNG >= 1.6.0
+* SmarthomeNG >= 1.8.0
 
 ## Configuration
 

--- a/ksemmodbus/__init__.py
+++ b/ksemmodbus/__init__.py
@@ -29,7 +29,7 @@ from lib.model.smartplugin import *
 from .ksem import Ksem
 
 class Ksemmodbus(SmartPlugin):
-    PLUGIN_VERSION = '1.6.2'
+    PLUGIN_VERSION = '1.6.3'
     ksem = 'None'
     _items = []
 

--- a/ksemmodbus/ksem.py
+++ b/ksemmodbus/ksem.py
@@ -8,17 +8,7 @@ import pymodbus
 
 from lib.model.smartplugin import *
 
-# pymodbus library from https://github.com/riptideio/pymodbus
-from pymodbus.version import version
-pymodbus_baseversion = int(version.short().split('.')[0])
-
-if pymodbus_baseversion > 2:
-    # for newer versions of pymodbus
-    from pymodbus.client.tcp import ModbusTcpClient
-else:
-    # for older versions of pymodbus
-    from pymodbus.client.sync import ModbusTcpClient
-
+from pymodbus.client.tcp import ModbusTcpClient
 from pymodbus.payload import BinaryPayloadDecoder
 from pymodbus.constants import Endian
 
@@ -56,51 +46,33 @@ class Ksem:
         return self.registers
 
     def __read_float(self, adr_dec):
-        if pymodbus_baseversion > 2:
-            result = self.client.read_holding_registers(adr_dec, 2, slave=71)
-        else:
-            result = self.client.read_holding_registers(adr_dec, 2, unit=71)
-        float_value = BinaryPayloadDecoder.fromRegisters(result.registers,byteorder=Endian.Big,wordorder=Endian.Little)
+        result = self.client.read_holding_registers(adr_dec, 2, slave=71)
+        float_value = BinaryPayloadDecoder.fromRegisters(result.registers,byteorder=Endian.BIG,wordorder=Endian.LITTLE)
         return round(float_value.decode_32bit_float(), 2)
 
     def __read_u16(self, adr_dec):
-        if pymodbus_baseversion > 2:
-            result = self.client.read_holding_registers(adr_dec, 1, slave=71)
-        else:
-            result = self.client.read_holding_registers(adr_dec, 1, unit=71)
-        u16_value = BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=Endian.Big,wordorder=Endian.Little)
+        result = self.client.read_holding_registers(adr_dec, 1, slave=71)
+        u16_value = BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=Endian.BIG,wordorder=Endian.LITTLE)
         return u16_value.decode_16bit_uint()
 
     def __read_u16_2(self, adr_dec):
-        if pymodbus_baseversion > 2:
-            result = self.client.read_holding_registers(adr_dec, 2, slave=71)
-        else:
-            result = self.client.read_holding_registers(adr_dec, 2, unit=71)
-        u16_2_value = BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=Endian.Big,wordorder=Endian.Little)
+        result = self.client.read_holding_registers(adr_dec, 2, slave=71)
+        u16_2_value = BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=Endian.BIG,wordorder=Endian.LITTLE)
         return u16_2_value.decode_16bit_uint()
 
     def __read_s16(self, adr_dec):
-        if pymodbus_baseversion > 2:
-            result = self.client.read_holding_registers(adr_dec, 1, slave=71)
-        else:
-            result = self.client.read_holding_registers(adr_dec, 1, unit=71)
-        s16_value = BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=Endian.Big,wordorder=Endian.Little)
+        result = self.client.read_holding_registers(adr_dec, 1, slave=71)
+        s16_value = BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=Endian.BIG,wordorder=Endian.LITTLE)
         return s16_value.decode_16bit_uint()
 
     def __read_u32(self, adr_dec):
-        if pymodbus_baseversion > 2:
-            result = self.client.read_holding_registers(adr_dec, 2, slave=71)
-        else:
-            result = self.client.read_holding_registers(adr_dec, 2, unit=71)
-        u32_value = BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=Endian.Big, wordorder=Endian.Big)
+        result = self.client.read_holding_registers(adr_dec, 2, slave=71)
+        u32_value = BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=Endian.BIG, wordorder=Endian.BIG)
         return round((u32_value.decode_32bit_uint() * 0.1), 2)
 
     def __read_u64(self, adr_dec):
-        if pymodbus_baseversion > 2:
-            result = self.client.read_holding_registers(adr_dec, 4, slave=71)
-        else:
-            result = self.client.read_holding_registers(adr_dec, 4, unit=71)
-        u64_value = BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=Endian.Big, wordorder=Endian.Big)
+        result = self.client.read_holding_registers(adr_dec, 4, slave=71)
+        u64_value = BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=Endian.BIG, wordorder=Endian.BIG)
         return round((u64_value.decode_64bit_uint() * 0.0001),2)
 
 

--- a/ksemmodbus/plugin.yaml
+++ b/ksemmodbus/plugin.yaml
@@ -5,15 +5,16 @@ plugin:
     description:
         de: 'Plugin zur Anbindung von einem Kostal Smart Energy Meter über Modbus an SmartHomeNG'
         en: 'Plugin to connect your Kostal Smart Energy Meter via modbus with SmartHomeNG'
-    maintainer: Thomas Hengsberg (thengsty)
+    maintainer: Thomas Hengsberg (thengsty), Cannon
     tester:
     state: develop                  # change to ready when done with development
     documentation:
     support:
 
-    version: 1.6.2                  # Plugin version
-    sh_minversion: 1.6              # minimum shNG version to use this plugin
+    version: 1.6.3                  # Plugin version
+    sh_minversion: 1.8              # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
+    py_minversion: 3.8              # minimum Python version to use this plugin
     multi_instance: False           # plugin supports multi instance
     restartable: unknown
     classname: Ksemmodbus         # class containing the plugin

--- a/ksemmodbus/requirements.txt
+++ b/ksemmodbus/requirements.txt
@@ -1,2 +1,1 @@
-pymodbus>=2.3,<3.0;python_version<'3.8'
-pymodbus>=3.0.2;python_version>="3.8"
+pymodbus>=3.5.2;python_version>='3.8'

--- a/modbus_tcp/__init__.py
+++ b/modbus_tcp/__init__.py
@@ -3,11 +3,11 @@
 #########################################################################
 #  Copyright 2022 De Filippis Ivan
 #  Copyright 2022 Ronny Schulz
-#  Copyright 2023 Bernd Meiners
 #########################################################################
 #  This file is part of SmartHomeNG.
 #
-#  Modbus_TCP plugin for SmartHomeNG
+#  Sample plugin for new plugins to run with SmartHomeNG version 1.4 and
+#  upwards.
 #
 #  SmartHomeNG is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -35,17 +35,7 @@ from pymodbus.constants import Endian
 from pymodbus.payload import BinaryPayloadDecoder
 from pymodbus.payload import BinaryPayloadBuilder
 
-# pymodbus library from https://github.com/riptideio/pymodbus
-from pymodbus.version import version
-
-pymodbus_baseversion = int(version.short().split('.')[0])
-
-if pymodbus_baseversion > 2:
-    # for newer versions of pymodbus
-    from pymodbus.client.tcp import ModbusTcpClient
-else:
-    # for older versions of pymodbus
-    from pymodbus.client.sync import ModbusTcpClient
+from pymodbus.client.tcp import ModbusTcpClient
 
 AttrAddress = 'modBusAddress'
 AttrType = 'modBusDataType'
@@ -56,19 +46,14 @@ AttrSlaveUnit = 'modBusUnit'
 AttrObjectType = 'modBusObjectType'
 AttrDirection = 'modBusDirection'
 
-
 class modbus_tcp(SmartPlugin):
-    """
-    This class provides a Plugin for SmarthomeNG to read and or write to modbus
-    devices.
-    """
-
+    ALLOW_MULTIINSTANCE = True
     PLUGIN_VERSION = '1.0.9'
 
     def __init__(self, sh, *args, **kwargs):
         """
-        Initializes the Modbus TCP plugin.
-        The parameters are retrieved from get_parameter_value(parameter_name)
+        Initializes the plugin. The parameters describe for this method are pulled from the entry in plugin.conf.
+        :param sh:  The instance of the smarthome object, save it for later references
         """
 
         self.logger.info('Init modbus_tcp plugin')
@@ -77,17 +62,8 @@ class modbus_tcp(SmartPlugin):
         super().__init__()
 
         self._host = self.get_parameter_value('host')
-        self._port = self.get_parameter_value('port')
-
-        self._cycle  = self.get_parameter_value('cycle')      # the frequency in seconds how often the device should be accessed
-        if self._cycle == 0:
-            self._cycle = None
-        self._crontab  = self.get_parameter_value('crontab')  # the more complex way to specify the device query frequency
-        if self._crontab == '':
-            self._crontab = None
-        if not (self._cycle or self._crontab):
-            self.logger.error(f"{self.get_fullname()}: no update cycle or crontab set. Modbus will not be queried automatically")
-        
+        self._port = int(self.get_parameter_value('port'))
+        self._cycle = int(self.get_parameter_value('cycle'))
         self._slaveUnit = int(self.get_parameter_value('slaveUnit'))
         self._slaveUnitRegisterDependend = False
 
@@ -102,30 +78,25 @@ class modbus_tcp(SmartPlugin):
 
         self.init_webinterface(WebInterface)
 
+
         return
 
     def run(self):
         """
         Run method for the plugin
         """
-        self.logger.debug(f"Plugin '{self.get_fullname()}': run method called")
+        self._sh.scheduler.add('modbusTCP_poll_device', self.poll_device, cycle=self._cycle)
         self.alive = True
-        if self._cycle or self._crontab:
-            # self.get_shortname()
-            self.scheduler_add('poll_device_' + self._host, self.poll_device, cycle=self._cycle, cron=self._crontab, prio=5)
-            #self.scheduler_add(self.get_shortname(), self._update_values_callback, prio=5, cycle=self._update_cycle, cron=self._update_crontab, next=shtime.now())
-        self.logger.debug(f"Plugin '{self.get_fullname()}': run method finished")
 
     def stop(self):
         """
         Stop method for the plugin
         """
         self.alive = False
-        self.logger.debug(f"Plugin '{self.get_fullname()}': stop method called")
-        self.scheduler_remove('poll_device_' + self._host)
+        self.logger.debug("stop modbus_tcp plugin")
+        self.scheduler_remove('modbusTCP_poll_device')
         self._Mclient.close()
         self.connected = False
-        self.logger.debug(f"Plugin '{self.get_fullname()}': stop method finished")
 
     def parse_item(self, item):
         """
@@ -136,15 +107,15 @@ class modbus_tcp(SmartPlugin):
         :param item:    The item to process.
         """
         if self.has_iattr(item.conf, AttrAddress):
-            self.logger.debug(f"parse item: {item}")
+            self.logger.debug("parse item: {0}".format(item))
             regAddr = int(self.get_iattr_value(item.conf, AttrAddress))
 
             objectType = 'HoldingRegister'
             value = item()
             dataType = 'uint16'
             factor = 1
-            byteOrder = 'Endian.Big'
-            wordOrder = 'Endian.Big'
+            byteOrder = 'Endian.BIG'
+            wordOrder = 'Endian.BIG'
             slaveUnit = self._slaveUnit
             dataDirection = 'read'
 
@@ -157,7 +128,7 @@ class modbus_tcp(SmartPlugin):
             if self.has_iattr(item.conf, AttrObjectType):
                 objectType = self.get_iattr_value(item.conf, AttrObjectType)
 
-            reg = str(objectType)  # dictionary key: objectType.regAddr.slaveUnit // HoldingRegister.528.1
+            reg = str(objectType)   # dictionary key: objectType.regAddr.slaveUnit // HoldingRegister.528.1
             reg += '.'
             reg += str(regAddr)
             reg += '.'
@@ -171,36 +142,34 @@ class modbus_tcp(SmartPlugin):
                 byteOrder = self.get_iattr_value(item.conf, AttrByteOrder)
             if self.has_iattr(item.conf, AttrWordOrder):
                 wordOrder = self.get_iattr_value(item.conf, AttrWordOrder)
-            if byteOrder == 'Endian.Big':  # Von String in Endian-Konstante "umwandeln"
-                byteOrder = Endian.Big
-            elif byteOrder == 'Endian.Little':
-                byteOrder = Endian.Little
+            if byteOrder == 'Endian.BIG':   # Von String in Endian-Konstante "umwandeln"
+                byteOrder = Endian.BIG
+            elif byteOrder == 'Endian.LITTLE':
+                byteOrder = Endian.LITTLE
             else:
-                byteOrder = Endian.Big
-                self.logger.warning("Invalid byte order -> default(Endian.Big) is used")
-            if wordOrder == 'Endian.Big':  # Von String in Endian-Konstante "umwandeln"
-                wordOrder = Endian.Big
-            elif wordOrder == 'Endian.Little':
-                wordOrder = Endian.Little
+                byteOrder = Endian.BIG
+                self.logger.warning("Invalid byte order -> default(Endian.BIG) is used")
+            if wordOrder == 'Endian.BIG':   # Von String in Endian-Konstante "umwandeln"
+                wordOrder = Endian.BIG
+            elif wordOrder == 'Endian.LITTLE':
+                wordOrder = Endian.LITTLE
             else:
-                wordOrder = Endian.Big
-                self.logger.warning("Invalid byte order -> default(Endian.Big) is used")
+                wordOrder = Endian.BIG
+                self.logger.warning("Invalid byte order -> default(Endian.BIG) is used")
 
-            regPara = {'regAddr': regAddr, 'slaveUnit': slaveUnit, 'dataType': dataType, 'factor': factor,
-                       'byteOrder': byteOrder,
-                       'wordOrder': wordOrder, 'item': item, 'value': value, 'objectType': objectType,
-                       'dataDir': dataDirection}
+            regPara = {'regAddr': regAddr, 'slaveUnit': slaveUnit, 'dataType': dataType, 'factor': factor, 'byteOrder': byteOrder,
+                       'wordOrder': wordOrder, 'item': item, 'value': value, 'objectType': objectType, 'dataDir': dataDirection }
             if dataDirection == 'read':
                 self._regToRead.update({reg: regPara})
-                self.logger.info(f"parse item: {item} Attributes {regPara}")
+                self.logger.info("parse item: {0} Attributes {1}".format(item, regPara))
             elif dataDirection == 'read_write':
                 self._regToRead.update({reg: regPara})
                 self._regToWrite.update({reg: regPara})
-                self.logger.info(f"parse item: {item} Attributes {regPara}")
+                self.logger.info("parse item: {0} Attributes {1}".format(item, regPara))
                 return self.update_item
             else:
-                self.logger.warning("Invalid data direction -> default(read) is used")
-                self._regToRead.update({reg: regPara})
+                 self.logger.warning("Invalid data direction -> default(read) is used")
+                 self._regToRead.update({reg: regPara})
 
     def poll_device(self):
         """
@@ -214,17 +183,18 @@ class modbus_tcp(SmartPlugin):
         with self.lock:
             try:
                 if self._Mclient.connect():
-                    self.logger.info(f"connected to {str(self._Mclient)}")
+                    self.logger.info("connected to {0}".format(str(self._Mclient)))
                     self.connected = True
                 else:
-                    self.logger.error(f"could not connect to {self._host}:{self._port}")
+                    self.logger.error("could not connect to {0}:{1}".format(self._host, self._port))
                     self.connected = False
                     return
 
             except Exception as e:
-                self.logger.error(f"connection exception: {str(self._Mclient)} {e}")
+                self.logger.error("connection expection: {0} {1}".format(str(self._Mclient), e))
                 self.connected = False
                 return
+
 
         startTime = datetime.now()
         regCount = 0
@@ -233,14 +203,14 @@ class modbus_tcp(SmartPlugin):
                 with self.lock:
                     regAddr = regPara['regAddr']
                     value = self.__read_Registers(regPara)
-                    # self.logger.debug(f"value read: {value} type: {type(value)}")
+                    #self.logger.debug("value readed: {0} type: {1}".format(value, type(value)))
                     if value is not None:
                         item = regPara['item']
                         if regPara['factor'] != 1:
                             value = value * regPara['factor']
-                            # self.logger.debug(f"value {value} multiply by: {regPara['factor']}")
+                            #self.logger.debug("value {0} multiply by: {1}".format(value, regPara['factor']))
                         item(value, self.get_fullname())
-                        regCount += 1
+                        regCount+=1
 
                         if 'read_dt' in regPara:
                             regPara['last_read_dt'] = regPara['read_dt']
@@ -253,13 +223,13 @@ class modbus_tcp(SmartPlugin):
             endTime = datetime.now()
             duration = endTime - startTime
             if regCount > 0:
-                self._pollStatus['last_dt'] = datetime.now()
-                self._pollStatus['regCount'] = regCount
-            self.logger.debug(f"poll_device: {regCount} register read required {duration} seconds")
+                self._pollStatus['last_dt']=datetime.now()
+                self._pollStatus['regCount']=regCount
+            self.logger.debug("poll_device: {0} register readed requed-time: {1}".format(regCount, duration))
         except Exception as e:
-            self.logger.error(f"something went wrong in the poll_device function: {e}")
+            self.logger.error("something went wrong in the poll_device function: {0}".format(e))
 
-    # called each time an item changes.
+     # called each time an item changes.
     def update_item(self, item, caller=None, source=None, dest=None):
         """
         Item has been updated
@@ -277,21 +247,22 @@ class modbus_tcp(SmartPlugin):
         slaveUnit = self._slaveUnit
         dataDirection = 'read'
 
+
         if caller == self.get_fullname():
-            # self.logger.debug(f'item was changed by the plugin itself - caller:{caller} source:{source} dest:{dest}')
+            #self.logger.debug('item was changed by the plugin itself - caller:{0} source:{1} dest:{2} '.format(caller, source, dest))
             return
 
         if self.has_iattr(item.conf, AttrDirection):
             dataDirection = self.get_iattr_value(item.conf, AttrDirection)
             if not dataDirection == 'read_write':
-                self.logger.debug(f'update_item: {item} Writing is not allowed - selected dataDirection:{dataDirection}')
+                self.logger.debug('update_item:{0} Writing is not allowed - selected dataDirection:{1}'.format(item, dataDirection))
                 return
-            # else:
-            #    self.logger.debug(f'update_item:{item} dataDirection: {dataDirection}')
+            #else:
+            #    self.logger.debug('update_item:{0} dataDirection:{1}'.format(item, dataDirection))
             if self.has_iattr(item.conf, AttrAddress):
                 regAddr = int(self.get_iattr_value(item.conf, AttrAddress))
             else:
-                self.logger.warning(f'update_item:{item} Item has no register address')
+                self.logger.warning('update_item:{0} Item has no register address'.format(item))
                 return
             if self.has_iattr(item.conf, AttrSlaveUnit):
                 slaveUnit = int(self.get_iattr_value(item.conf, AttrSlaveUnit))
@@ -302,7 +273,7 @@ class modbus_tcp(SmartPlugin):
             else:
                 return
 
-            reg = str(objectType)  # Dict-key: HoldingRegister.528.1 *** objectType.regAddr.slaveUnit ***
+            reg = str(objectType)   # Dict-key: HoldingRegister.528.1 *** objectType.regAddr.slaveUnit ***
             reg += '.'
             reg += str(regAddr)
             reg += '.'
@@ -310,18 +281,18 @@ class modbus_tcp(SmartPlugin):
             if reg in self._regToWrite:
                 with self.lock:
                     regPara = self._regToWrite[reg]
-                    self.logger.debug(f'update_item:{item} value:{item()} regToWrite: {reg}')
+                    self.logger.debug('update_item:{0} value:{1} regToWrite:{2}'.format(item, item(), reg))
                     try:
                         if self._Mclient.connect():
-                            self.logger.info(f"connected to {str(self._Mclient)}")
+                            self.logger.info("connected to {0}".format(str(self._Mclient)))
                             self.connected = True
                         else:
-                            self.logger.error(f"could not connect to {self._host}:{self._port}")
+                            self.logger.error("could not connect to {0}:{1}".format(self._host, self._port))
                             self.connected = False
                             return
 
                     except Exception as e:
-                        self.logger.error(f"connection exception: {str(self._Mclient)} {e}")
+                        self.logger.error("connection expection: {0} {1}".format(str(self._Mclient), e))
                         self.connected = False
                         return
 
@@ -330,7 +301,7 @@ class modbus_tcp(SmartPlugin):
                     try:
                         self.__write_Registers(regPara, item())
                     except Exception as e:
-                        self.logger.error(f"something went wrong in the __write_Registers function: {e}")
+                        self.logger.error("something went wrong in the __write_Registers function: {0}".format(e))
 
     def __write_Registers(self, regPara, value):
         objectType = regPara['objectType']
@@ -339,8 +310,8 @@ class modbus_tcp(SmartPlugin):
         bo = regPara['byteOrder']
         wo = regPara['wordOrder']
         dataTypeStr = regPara['dataType']
-        dataType = ''.join(filter(str.isalpha, dataTypeStr))  # vom dataType die Ziffen entfernen z.B. uint16 = uint
-        registerCount = 0  # Anzahl der zu schreibenden Register (Words)
+        dataType = ''.join(filter(str.isalpha, dataTypeStr))    # vom dataType die Ziffen entfernen z.B. uint16 = uint
+        registerCount = 0   # Anzahl der zu schreibenden Register (Words)
 
         try:
             bits = int(''.join(filter(str.isdigit, dataTypeStr)))  # bit-Zahl aus aus dataType z.B. uint16 = 16
@@ -348,15 +319,15 @@ class modbus_tcp(SmartPlugin):
             bits = 16
 
         if dataType.lower() == 'string':
-            registerCount = int(bits / 2)  # bei string: bits = bytes !! string16 -> 16Byte - 8 registerCount
+            registerCount = int(bits/2)  # bei string: bits = bytes !! string16 -> 16Byte - 8 registerCount
         else:
-            registerCount = int(bits / 16)
+            registerCount = int(bits/16)
 
         if regPara['factor'] != 1:
-            # self.logger.debug(f"value {value} divided by: {regPara['factor']}")
-            value = value * (1 / regPara['factor'])
+            #self.logger.debug("value {0} divided by: {1}".format(value, regPara['factor']))
+            value = value * (1/regPara['factor'])
 
-        self.logger.debug(f"write {value} to {objectType}.{address}.{address} (address.slaveUnit) dataType:{dataTypeStr}")
+        self.logger.debug("write {0} to {1}.{2}.{3} (address.slaveUnit) dataType:{4}".format(value, objectType, address, slaveUnit, dataTypeStr))
         builder = BinaryPayloadBuilder(byteorder=bo, wordorder=wo)
 
         if dataType.lower() == 'uint':
@@ -367,7 +338,7 @@ class modbus_tcp(SmartPlugin):
             elif bits == 64:
                 builder.add_64bit_uint(int(value))
             else:
-                self.logger.error(f"Number of bits or datatype not supported : {dataTypeStr}")
+                self.logger.error("Number of bits or datatype not supported : {0}".format(dataTypeStr))
         elif dataType.lower() == 'int':
             if bits == 16:
                 builder.add_16bit_int(int(value))
@@ -376,28 +347,28 @@ class modbus_tcp(SmartPlugin):
             elif bits == 64:
                 builder.add_64bit_int(int(value))
             else:
-                self.logger.error(f"Number of bits or datatype not supported : {dataTypeStr}")
+                self.logger.error("Number of bits or datatype not supported : {0}".format(dataTypeStr))
         elif dataType.lower() == 'float':
             if bits == 32:
-                builder.add_32bit_float(value)
-            elif bits == 64:
-                builder.add_64bit_float(value)
+                 builder.add_32bit_float(value)
+            if bits == 64:
+                 builder.add_64bit_float(value)
             else:
-                self.logger.error(f"Number of bits or datatype not supported : {dataTypeStr}")
+                self.logger.error("Number of bits or datatype not supported : {0}".format(dataTypeStr))
         elif dataType.lower() == 'string':
             builder.add_string(value)
         elif dataType.lower() == 'bit':
             if objectType == 'Coil' or objectType == 'DiscreteInput':
-                if not isinstance(value, bool):  # test is boolean
-                    self.logger.error(f"Value is not boolean: {value}")
+                if not type(value) == type(True):   # test is boolean
+                    self.logger.error("Value is not boolean: {0}".format(value))
                     return
             else:
-                if set(value).issubset({'0', '1'}) and bool(value):  # test is bit-string '00110101'
+                if set(value).issubset({'0', '1'}) and bool(value):   # test is bit-string '00110101'
                     builder.add_bits(value)
                 else:
-                    self.logger.error(f"Value is not a bitstring: {value}")
+                    self.logger.error("Value is not a bitstring: {0}".format(value))
         else:
-            self.logger.error(f"Number of bits or datatype not supported : {dataTypeStr}")
+            self.logger.error("Number of bits or datatype not supported : {0}".format(dataTypeStr))
             return None
 
         if objectType == 'Coil':
@@ -406,15 +377,15 @@ class modbus_tcp(SmartPlugin):
             registers = builder.to_registers()
             result = self._Mclient.write_registers(address, registers, unit=slaveUnit)
         elif objectType == 'DiscreteInput':
-            self.logger.warning(f"this object type cannot be written {objectType}:{address} slaveUnit:{slaveUnit}")
+            self.logger.warning("this object type cannot be written {0}:{1} slaveUnit:{2}".format(objectType, address, slaveUnit))
             return
         elif objectType == 'InputRegister':
-            self.logger.warning(f"this object type cannot be written {objectType}:{address} slaveUnit:{slaveUnit}")
+            self.logger.warning("this object type cannot be written {0}:{1} slaveUnit:{2}".format(objectType, address, slaveUnit))
             return
         else:
             return
         if result.isError():
-            self.logger.error(f"write error: {result} {objectType}.{address}.{slaveUnit} (address.slaveUnit)")
+            self.logger.error("write error: {0} {1}.{2}.{3} (address.slaveUnit)".format(result, objectType, address, slaveUnit))
             return None
 
         if 'write_dt' in regPara:
@@ -429,8 +400,9 @@ class modbus_tcp(SmartPlugin):
         else:
             regPara.update({'write_value': value})
 
-        # regPara['write_dt'] = datetime.now()
-        # regPara['write_value'] = value
+        #regPara['write_dt'] = datetime.now()
+        #regPara['write_value'] = value
+
 
     def __read_Registers(self, regPara):
         objectType = regPara['objectType']
@@ -449,41 +421,29 @@ class modbus_tcp(SmartPlugin):
             bits = 16
 
         if dataType.lower() == 'string':
-            registerCount = int(bits / 2)  # bei string: bits = bytes !! string16 -> 16Byte - 8 registerCount
+            registerCount = int(bits/2)  # bei string: bits = bytes !! string16 -> 16Byte - 8 registerCount
         else:
-            registerCount = int(bits / 16)
+            registerCount = int(bits/16)
 
         if self.connected == False:
-            self.logger.error(f"not connected to {self._host}:{self._port}")
+            self.logger.error(" not connect {0}:{1}".format(self._host, self._port))
             return None
 
-        # self.logger.debug(f"read {objectType}.{address}.{slaveUnit} (address.slaveUnit) regCount:{registerCount}")
+        #self.logger.debug("read {0}.{1}.{2} (address.slaveUnit) regCount:{3}".format(objectType, address, slaveUnit, registerCount))
         if objectType == 'Coil':
-            if pymodbus_baseversion > 2:
-                result = self._Mclient.read_coils(address, registerCount, slave=slaveUnit)
-            else:
-                result = self._Mclient.read_coils(address, registerCount, unit=slaveUnit)
+            result = self._Mclient.read_coils(address, registerCount, slave=slaveUnit)
         elif objectType == 'DiscreteInput':
-            if pymodbus_baseversion > 2:
-                result = self._Mclient.read_discrete_inputs(address, registerCount, slave=slaveUnit)
-            else:
-                result = self._Mclient.read_discrete_inputs(address, registerCount, unit=slaveUnit)
+            result = self._Mclient.read_discrete_inputs(address, registerCount, slave=slaveUnit)
         elif objectType == 'InputRegister':
-            if pymodbus_baseversion > 2:
-                result = self._Mclient.read_input_registers(address, registerCount, slave=slaveUnit)
-            else:
-                result = self._Mclient.read_input_registers(address, registerCount, unit=slaveUnit)
+            result = self._Mclient.read_input_registers(address, registerCount, slave=slaveUnit)
         elif objectType == 'HoldingRegister':
-            if pymodbus_baseversion > 2:
-                result = self._Mclient.read_holding_registers(address, registerCount, slave=slaveUnit)
-            else:
-                result = self._Mclient.read_holding_registers(address, registerCount, unit=slaveUnit)
+            result = self._Mclient.read_holding_registers(address, registerCount, slave=slaveUnit)
         else:
-            self.logger.error(f"{AttrObjectType} not supported: {objectType}")
+            self.logger.error("{0} not supported: {1}".format(AttrObjectType, objectType))
             return None
 
         if result.isError():
-            self.logger.error(f"read error: {result} {objectType}.{address}.{slaveUnit} (address.slaveUnit) regCount:{registerCount}")
+            self.logger.error("read error: {0} {1}.{2}.{3} (address.slaveUnit) regCount:{4}".format(result, objectType, address, slaveUnit, registerCount))
             return None
 
         if objectType == 'Coil':
@@ -491,11 +451,11 @@ class modbus_tcp(SmartPlugin):
         elif objectType == 'DiscreteInput':
             value = result.bits[0]
         elif objectType == 'InputRegister':
-            decoder = BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=bo, wordorder=wo)
+            decoder = BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=bo,wordorder=wo)
         else:
-            decoder = BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=bo, wordorder=wo)
+            decoder = BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=bo,wordorder=wo)
 
-        self.logger.debug(f"read {objectType}.{address}.{slaveUnit} (address.slaveUnit) regCount:{registerCount} result:{result}")
+        self.logger.debug("read {0}.{1}.{2} (address.slaveUnit) regCount:{3} result:{4}".format(objectType, address, slaveUnit, registerCount, result))
 
         if dataType.lower() == 'uint':
             if bits == 16:
@@ -505,7 +465,7 @@ class modbus_tcp(SmartPlugin):
             elif bits == 64:
                 return decoder.decode_64bit_uint()
             else:
-                self.logger.error(f"Number of bits or datatype not supported : {dataTypeStr}")
+                self.logger.error("Number of bits or datatype not supported : {0}".format(dataTypeStr))
         elif dataType.lower() == 'int':
             if bits == 16:
                 return decoder.decode_16bit_int()
@@ -514,25 +474,25 @@ class modbus_tcp(SmartPlugin):
             elif bits == 64:
                 return decoder.decode_64bit_int()
             else:
-                self.logger.error(f"Number of bits or datatype not supported : {dataTypeStr}")
+                self.logger.error("Number of bits or datatype not supported : {0}".format(dataTypeStr))
         elif dataType.lower() == 'float':
             if bits == 32:
                 return decoder.decode_32bit_float()
-            elif bits == 64:
+            if bits == 64:
                 return decoder.decode_64bit_float()
             else:
-                self.logger.error(f"Number of bits or datatype not supported : {dataTypeStr}")
+                self.logger.error("Number of bits or datatype not supported : {0}".format(dataTypeStr))
         elif dataType.lower() == 'string':
             # bei string: bits = bytes !! string16 -> 16Byte
             ret = decoder.decode_string(bits)
-            return str(ret, 'ASCII')
+            return str( ret, 'ASCII')
         elif dataType.lower() == 'bit':
             if objectType == 'Coil' or objectType == 'DiscreteInput':
-                # self.logger.debug(f"read bit value: {value}")
+                #self.logger.debug("readed bit value: {0}".format(value))
                 return value
             else:
-                self.logger.debug(f"read bits values: {value.decode_bits()}")
+                self.logger.debug("readed bits values: {0}".format(value.decode_bits()))
                 return decoder.decode_bits()
         else:
-            self.logger.error(f"Number of bits or datatype not supported : {dataTypeStr}")
+            self.logger.error("Number of bits or datatype not supported : {0}".format(dataTypeStr))
         return None

--- a/modbus_tcp/plugin.yaml
+++ b/modbus_tcp/plugin.yaml
@@ -5,17 +5,15 @@ plugin:
     description:
         de: 'Plugin zur Geräte-Anbindung über ModBus an SmartHomeNG'
         en: 'Plugin to connect via modbus with SmartHomeNG'
-    maintainer: ivande
-    tester: NONE                   # Who tests this plugin?
+    maintainer: ivande, Cannon
+    tester: 'n/a'
     state: ready
-    keywords: modbus_tcp modbus smartmeter inverter heatpump
-    #documentation: http://smarthomeng.de/user/plugins/modbus_tcp/user_doc.html
+    keywords: modbus_tcp
+    #documentation: https://github.com/smarthomeNG/plugins/blob/develop/modbus_tcp/user_doc.rst
     support: https://knx-user-forum.de/forum/supportforen/smarthome-py/1154368-einbindung-von-modbus-tcp
     version: 1.0.9                 # Plugin version
     sh_minversion: 1.8             # minimum shNG version to use this plugin
-    #sh_maxversion:                # maximum shNG version to use this plugin (leave empty if latest)
-    py_minversion: 3.6
-    # py_maxversion:               # maximum Python version to use for this plugin (leave empty if latest)
+    py_minversion: 3.8
     multi_instance: True           # plugin supports multi instance
     restartable: unknown
     classname: modbus_tcp          # class containing the plugin
@@ -28,26 +26,17 @@ parameters:
             en: 'IP address from the modbus-device'
 
     port:
-        type: int
-        valid_min: 0
-        valid_max: 65535
+        type: num
         description:
             de: 'modbus Port'
             en: 'modbus port'
 
     cycle:
-        type: int
+        type: num
         default: 300
-        valid_min: 0
         description:
-            de: 'Update Zyklus in Sekunden. Wenn der Wert 0 ist, wird keine Abfrage über cycle ausgeführt'
-            en: 'Update cycle in seconds. If value is 0 then noch query will be made by means of cycle'
-
-    crontab:
-        type: str
-        description:
-            de: 'Update mit Festlegung via Crontab'
-            en: 'Update by means of a crontab'
+            de: 'Update Zyklus in Sekunden'
+            en: 'Update cycle in seconds'
 
     slaveUnit:
         type: num
@@ -64,10 +53,10 @@ item_attributes:
             de: 'Auswahl welcher Objekt-Type gelesen werden soll'
             en: 'Selection of which object type should be read '
         valid_list:
-            - 'Coil'
-            - 'DiscreteInput'
-            - 'InputRegister'
-            - 'HoldingRegister'
+        - 'Coil'
+        - 'DiscreteInput'
+        - 'InputRegister'
+        - 'HoldingRegister'
 
     modBusAddress:
         type: num
@@ -96,9 +85,9 @@ item_attributes:
             de: 'Datenrichtung'
             en: 'data direction'
         valid_list:
-            - 'read'
-            - 'read_write'
-            - 'write'
+        - 'read'
+        - 'read_write'
+        - 'write'
 
     modBusByteOrder:
         type: str
@@ -107,8 +96,8 @@ item_attributes:
             de: 'Endian.Big oder Endian.Little'
             en: 'Endian.Big or Endian.Little'
         valid_list:
-            - 'Endian.Big'
-            - 'Endian.Little'
+        - 'Endian.Big'
+        - 'Endian.Little'
 
     modBusWordOrder:
         type: str
@@ -117,14 +106,14 @@ item_attributes:
             de: 'Endian.Big oder Endian.Little'
             en: 'Endian.Big or Endian.Little'
         valid_list:
-            - 'Endian.Big'
-            - 'Endian.Little'
+        - 'Endian.Big'
+        - 'Endian.Little'
 
     modBusFactor:
         type: num
         default: 1
         description:
-            de: 'Faktor mit dem der gelesene Register-Wert multipliziert wird'
+            de: 'Faktor mit welchem der gelesene Register-Wert multipliziert wird'
             en: 'Factor by which the read register value is multiplied'
 
 item_structs: NONE

--- a/modbus_tcp/requirements.txt
+++ b/modbus_tcp/requirements.txt
@@ -1,2 +1,1 @@
-pymodbus>=2.3,<3.0;python_version<'3.8'
-pymodbus>=3.0.2;python_version>="3.8"
+pymodbus>=3.5.2;python_version>='3.8'

--- a/modbus_tcp/user_doc.rst
+++ b/modbus_tcp/user_doc.rst
@@ -6,39 +6,30 @@
 modbus_tcp
 ==========
 
-.. image:: webif/static/img/plugin_logo.png
-   :alt: plugin logo
-   :width: 300px
-   :height: 300px
-   :scale: 50 %
-   :align: left
-
 SmarthomeNG plugin, zum Lesen von Register über ModBusTCP
 
 Anforderungen
-=============
-
-* Python > 3.6
-* pymodbus >= 2.5.3
+-------------
+* Python >= 3.8
+* pymodbus >= 3.5.2
 * SmarthomeNG >= 1.8.0
 
 pymodbus
---------
-
+~~~~~~~~
 das Paket sollte automatisch von SH installiert werden.
 
 pymodbus - manuelle Installation:
----------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code:: shell-session
 
-    python3 -m pip install pymodbus --user --upgrade
+    pip install pymodbus
 
 Konfiguration
-=============
+-------------
 
 plugin.yaml
------------
+~~~~~~~~~~~
 
 .. code-block:: yaml
 
@@ -64,13 +55,13 @@ Bitte die Dokumentation lesen, die aus den Metadaten der plugin.yaml erzeugt wur
 
 
 items.yaml
-----------
+~~~~~~~~~~
 
 Bitte die Dokumentation lesen, die aus den Metadaten der plugin.yaml erzeugt wurde.
 
 
 logic.yaml
-----------
+~~~~~~~~~~
 
 Bitte die Dokumentation lesen, die aus den Metadaten der plugin.yaml erzeugt wurde.
 
@@ -164,12 +155,9 @@ siehe auch example.yaml
 
 Changelog
 ---------
-V1.0.9  
+V1.0.8  work with newer versions of pymodbus too, minimum pymodbus now 2.5.3
 
-V1.0.8  Neuere Pymodbus Versionen können nun verwendet werden.
-        Di minimale Version für Pymodbus ist jetzt 2.5.3
-
-V1.0.7  Verbindung offen halten und lock nutzen um Thread Sicherheit zu erreichen (CaeruleusAqua and bmxp)
+V1.0.7  keep connection open and use locking to ensure thread safety (CaeruleusAqua and bmxp)
         Fehler behoben: nicht deklarierte Variable "TypeStr" und "bitstr"
 
 V1.0.6  schreiben von Register (HoldingRegister, Coil)
@@ -192,7 +180,7 @@ V1.0.0  Initial plugin version
 
 
 Web Interface
-=============
+-------------
 
 Das Plugin kann aus dem Admin Interface aufgerufen werden. Dazu auf der Seite Plugins in der entsprechenden
 Zeile das Icon in der Spalte **Web Interface** anklicken.

--- a/pluggit/README.md
+++ b/pluggit/README.md
@@ -24,6 +24,13 @@ struct: pluggit.pluggit
 
 ## Änderungen:
 
+V2.0.6 - 15.09.2023
+- Anpassung für pymodbus 3.5.2: bytorder und wordorder musste korrrigiert werden, statt Little und Big nun LITTLE und BIG
+- Python muss >= 3.8 sein und pymodbus >= 3.5.2
+
+V2.05 - 11.09.2023
+- unter Python 10 muss mindestens die Version 3.3.2 von pymodbus laufen, da sonst Verbindungsprobleme
+
 V2.0.4 - 13.11.2022
 - Verbesserungen zur Versionsprüfung "pymodbus"
 

--- a/pluggit/__init__.py
+++ b/pluggit/__init__.py
@@ -29,23 +29,15 @@ import threading
 import logging
 from lib.model.smartplugin import SmartPlugin
 
-# pymodbus library from https://github.com/riptideio/pymodbus
-from pymodbus.version import version
-pymodbus_baseversion = int(version.short().split('.')[0])
-
-if pymodbus_baseversion > 2:
-    # for newer versions of pymodbus
-    from pymodbus.client.tcp import ModbusTcpClient
-else:
-    # for older versions of pymodbus
-    from pymodbus.client.sync import ModbusTcpClient
+# pymodbus library from https://github.com/pymodbus-dev/pymodbus
+from pymodbus.client.tcp import ModbusTcpClient
 
 from pymodbus.constants import Endian
 from pymodbus.payload import BinaryPayloadDecoder
 from pymodbus.payload import BinaryPayloadBuilder
 
 class Pluggit(SmartPlugin):
-    PLUGIN_VERSION="2.0.4"
+    PLUGIN_VERSION="2.0.6"
 
     _itemReadDictionary = {}
     _itemWriteDictionary = {}
@@ -378,7 +370,7 @@ class Pluggit(SmartPlugin):
                 if unitstate != -1:
                     pluggit_paramList = self._modbusRegisterDictionary['prmRamIdxUnitMode']
                     registerValue = self._Pluggit.read_holding_registers(pluggit_paramList[self.DICT_READ_ADDRESS], pluggit_paramList[self.DICT_ADDRESS_QUANTITY])
-                    vdecoder = BinaryPayloadDecoder.fromRegisters(registerValue.registers, byteorder=Endian.Big, wordorder=Endian.Little)
+                    vdecoder = BinaryPayloadDecoder.fromRegisters(registerValue.registers, byteorder=Endian.BIG, wordorder=Endian.LITTLE)
                     readItemValue = vdecoder.decode_16bit_uint()
                     #if readItemValue & unitstate != unitstate:
                         # workaround for manual bypass timeout
@@ -472,7 +464,7 @@ class Pluggit(SmartPlugin):
                     registerValue = self._Pluggit.read_holding_registers(pluggit_paramList[self.DICT_READ_ADDRESS], pluggit_paramList[self.DICT_ADDRESS_QUANTITY])
                     # TODO: auswerten, wenn Reigister nicht auslesbar
                     readCacheDictionary[pluggit_key] = registerValue
-                vdecoder = BinaryPayloadDecoder.fromRegisters(registerValue.registers, byteorder=Endian.Big, wordorder=Endian.Little)
+                vdecoder = BinaryPayloadDecoder.fromRegisters(registerValue.registers, byteorder=Endian.BIG, wordorder=Endian.LITTLE)
 
                 readItemValue = None
                     

--- a/pluggit/changes.txt
+++ b/pluggit/changes.txt
@@ -1,0 +1,8 @@
+15.09.2023:
+- Anpassung für pymodbus 3.5.2: bytorder und wordorder musste korrrigiert werden, statt Little und Big nun LITTLE und BIG
+
+11.09.2023:
+- unter Python 10 muss mindestens die Version 3.3.2 von pymodbus laufen, da sonst Verbindungsprobleme
+
+23.07.2023:
+- pymodbus mindestens Version 3.3.0, da Versionsmanagement geändert wurde, Version 2 wird nicht mehr unterstützt

--- a/pluggit/plugin.yaml
+++ b/pluggit/plugin.yaml
@@ -11,7 +11,7 @@ plugin:
     keywords: modbus
 #    documentation:
 #    support:
-    version: 2.0.4                  # Plugin version
+    version: 2.0.6                  # Plugin version
     sh_minversion: 1.8              # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False           # plugin supports multi instance

--- a/pluggit/requirements.txt
+++ b/pluggit/requirements.txt
@@ -1,2 +1,1 @@
-pymodbus>=2.3,<3.0;python_version<'3.8'
-pymodbus>=3.0.2;python_version>="3.8"
+pymodbus>=3.5.2;python_version>='3.8'

--- a/sma_mb/README.md
+++ b/sma_mb/README.md
@@ -1,8 +1,8 @@
-Auf Grund von Abhängigkeiten der Versionen zu Python, SmartHomeNG usw. pymodbus mindestens mit Version 2.5.3.
+Auf Grund von Abhängigkeiten der Versionen zu Python, SmartHomeNG usw. pymodbus mindestens mit Version 3.5.2.
 
 sudo pip3 uninstall pymodbus
 
-sudo pip3 install pymodbus==2.5.3
+sudo pip3 install pymodbus>=3.5.2
 
 ###plugin_yaml:
 

--- a/sma_mb/__init__.py
+++ b/sma_mb/__init__.py
@@ -36,17 +36,7 @@ from .webif import WebInterface
 
 import time
 
-# pymodbus library from https://github.com/riptideio/pymodbus
-from pymodbus.version import version
-pymodbus_baseversion = int(version.short().split('.')[0])
-
-if pymodbus_baseversion > 2:
-    # for newer versions of pymodbus
-    from pymodbus.client.tcp import ModbusTcpClient
-else:
-    # for older versions of pymodbus
-    from pymodbus.client.sync import ModbusTcpClient
-
+from pymodbus.client.tcp import ModbusTcpClient
 from pymodbus.constants import Endian
 from pymodbus.payload import BinaryPayloadDecoder
 
@@ -63,7 +53,7 @@ class SMAModbus(SmartPlugin):
     are already available!
     """
 
-    PLUGIN_VERSION = '1.5.3'    # (must match the version specified in plugin.yaml), use '1.0.0' for your initial plugin Release
+    PLUGIN_VERSION = '1.5.4'    # (must match the version specified in plugin.yaml), use '1.0.0' for your initial plugin Release
 
     def __init__(self, sh):
         """
@@ -203,14 +193,11 @@ class SMAModbus(SmartPlugin):
             else:
                 register_count = 2
             try:
-                if pymodbus_baseversion > 2:
-                    result = client.read_holding_registers((int(read_parameter)), register_count, slave=3)
-                else:
-                    result = client.read_holding_registers((int(read_parameter)), register_count, unit=3)
+                result = client.read_holding_registers((int(read_parameter)), register_count, slave=3)
             except Exception as e:
                 self.logger.error(f"poll_device: Item {self._items[read_parameter].property.path} - Error trying to get result, got Exception {e}")
             else:
-                decoder = BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=Endian.Big)
+                decoder = BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=Endian.BIG)
                 if self._datatypes[read_parameter] == 'S16':
                     decoded = {'value': decoder.decode_16bit_int()}
                 elif self._datatypes[read_parameter] == 'U16':

--- a/sma_mb/plugin.yaml
+++ b/sma_mb/plugin.yaml
@@ -5,17 +5,17 @@ plugin:
     description:
         de: 'Dieses Plugin liest die aktuellen Werte eines SMA-Wechselrichters per SMA Speedwire Feldbus/Modbus aus'
         en: 'This plug-in reads the current values of an SMA inverter via SMA Speedwire fieldbus/Modbus'
-    maintainer: kla.b, msinn
+    maintainer: kla.b, msinn, Cannon
     tester: kla.b, Hochpass, sipple   # Who tests this plugin?
     state: ready                    # change to ready when done with development
 #    keywords: iot xyz
 #    documentation: https://github.com/smarthomeNG/smarthome/wiki/CLI-Plugin        # url of documentation (wiki) page
 #    support: https://knx-user-forum.de/forum/supportforen/smarthome-py
 
-    version: 1.5.3                  # Plugin version (must match the version specified in __init__.py)
-    sh_minversion: 1.7              # minimum shNG version to use this plugin
+    version: 1.5.4                  # Plugin version (must match the version specified in __init__.py)
+    sh_minversion: 1.8              # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
-#    py_minversion: 3.6             # minimum Python version to use for this plugin
+    py_minversion: 3.8              # minimum Python version to use for this plugin
 #    py_maxversion:                 # maximum Python version to use for this plugin (leave empty if latest)
     multi_instance: True            # plugin supports multi instance
     restartable: unknown

--- a/sma_mb/requirements.txt
+++ b/sma_mb/requirements.txt
@@ -1,2 +1,1 @@
-pymodbus>=2.3,<3.0;python_version<'3.8'
-pymodbus>=3.0.2;python_version>="3.8"
+pymodbus>=3.5.2;python_version>='3.8'

--- a/sma_mb/user_doc.rst
+++ b/sma_mb/user_doc.rst
@@ -23,7 +23,7 @@ Notwendige Software
 
 Folgende Python Packages werden benötigt:
 
-* pymodbus >= 2.5.3
+* pymodbus >= 3.5.2
 
 
 Unterstützte Geräte


### PR DESCRIPTION
- Changes for pymodbus 3.5.2
- Support for pymodbus 2.x dropped

Because of many changes in pymodbus and some incompatibilities with different pymodbus-versions, I've dropped the support of pymodbus 2.x. Also Python >= 3.8 is neccessary.

The pluggit plugin is tested and working. All other plugins like ksemmodbus, kostalmodbus, modbus_tcp and sma_mb are untested.