### PR TITLE
xiaomi_vac plugin: add zeroconf 0.52.0 as requirement 

### DIFF
--- a/xiaomi_vac/requirements.txt
+++ b/xiaomi_vac/requirements.txt
@@ -1,2 +1,3 @@
+zeroconf<=0.52.0
 python-miio==0.4.6;python_version<'3.6'
 python-miio>=0.4.7;python_version>='3.6'


### PR DESCRIPTION
because otherwise creating wheel of newer version might not work for Raspi bookworm