### PR TITLE
Pluggit

### DIFF
--- a/pluggit/README.md
+++ b/pluggit/README.md
@@ -24,6 +24,13 @@ struct: pluggit.pluggit
 
 ## Änderungen:
 
+V2.0.6 - 15.09.2023
+- Anpassung für pymodbus 3.5.2: bytorder und wordorder musste korrrigiert werden, statt Little und Big nun LITTLE und BIG
+- Python muss >= 3.8 sein und pymodbus >= 3.5.2
+
+V2.05 - 11.09.2023
+- unter Python 10 muss mindestens die Version 3.3.2 von pymodbus laufen, da sonst Verbindungsprobleme
+
 V2.0.4 - 13.11.2022
 - Verbesserungen zur Versionsprüfung "pymodbus"
 

--- a/pluggit/__init__.py
+++ b/pluggit/__init__.py
@@ -29,23 +29,15 @@ import threading
 import logging
 from lib.model.smartplugin import SmartPlugin
 
-# pymodbus library from https://github.com/riptideio/pymodbus
-from pymodbus.version import version
-pymodbus_baseversion = int(version.short().split('.')[0])
-
-if pymodbus_baseversion > 2:
-    # for newer versions of pymodbus
-    from pymodbus.client.tcp import ModbusTcpClient
-else:
-    # for older versions of pymodbus
-    from pymodbus.client.sync import ModbusTcpClient
+# pymodbus library from https://github.com/pymodbus-dev/pymodbus
+from pymodbus.client.tcp import ModbusTcpClient
 
 from pymodbus.constants import Endian
 from pymodbus.payload import BinaryPayloadDecoder
 from pymodbus.payload import BinaryPayloadBuilder
 
 class Pluggit(SmartPlugin):
-    PLUGIN_VERSION="2.0.4"
+    PLUGIN_VERSION="2.0.6"
 
     _itemReadDictionary = {}
     _itemWriteDictionary = {}
@@ -378,7 +370,7 @@ class Pluggit(SmartPlugin):
                 if unitstate != -1:
                     pluggit_paramList = self._modbusRegisterDictionary['prmRamIdxUnitMode']
                     registerValue = self._Pluggit.read_holding_registers(pluggit_paramList[self.DICT_READ_ADDRESS], pluggit_paramList[self.DICT_ADDRESS_QUANTITY])
-                    vdecoder = BinaryPayloadDecoder.fromRegisters(registerValue.registers, byteorder=Endian.Big, wordorder=Endian.Little)
+                    vdecoder = BinaryPayloadDecoder.fromRegisters(registerValue.registers, byteorder=Endian.BIG, wordorder=Endian.LITTLE)
                     readItemValue = vdecoder.decode_16bit_uint()
                     #if readItemValue & unitstate != unitstate:
                         # workaround for manual bypass timeout
@@ -472,7 +464,7 @@ class Pluggit(SmartPlugin):
                     registerValue = self._Pluggit.read_holding_registers(pluggit_paramList[self.DICT_READ_ADDRESS], pluggit_paramList[self.DICT_ADDRESS_QUANTITY])
                     # TODO: auswerten, wenn Reigister nicht auslesbar
                     readCacheDictionary[pluggit_key] = registerValue
-                vdecoder = BinaryPayloadDecoder.fromRegisters(registerValue.registers, byteorder=Endian.Big, wordorder=Endian.Little)
+                vdecoder = BinaryPayloadDecoder.fromRegisters(registerValue.registers, byteorder=Endian.BIG, wordorder=Endian.LITTLE)
 
                 readItemValue = None
                     

--- a/pluggit/_pv_2_0_4/README.md
+++ b/pluggit/_pv_2_0_4/README.md
@@ -1,0 +1,58 @@
+# pluggit
+SmartHomeNG plugin pluggit
+
+Das SmartHomeNG plugin für eine Pluggit AP310 KWL
+
+## Einbindung in der plugin.yaml mit:
+
+```python
+pluggit:
+    class_name: Pluggit
+    class_path: plugins.pluggit
+    host: 192.168.1.4
+    #cycle: 300
+```
+
+host = IP-Adresse der pluggit  
+cycle = Update-Interfall der abzufragenden Werte (optional)
+
+## Einbindung in den Items per Item-Struct:
+
+```python
+struct: pluggit.pluggit
+```
+
+## Änderungen:
+
+V2.0.4 - 13.11.2022
+- Verbesserungen zur Versionsprüfung "pymodbus"
+
+V2.0.3 - 25.10.2022
+- Support für pymodbus 3.0
+
+22.05.2022:
+- Fehler mit manuellem Bypass behoben
+
+16.02.2022:
+- CurentUnitMode.ManualBypass dem Item-struct zugefügt
+- Log-Level für verschiedene Ausgaben angepasst
+- CurrentUnitMode.AwayMode repariert
+
+24.02.2021:
+- Item-struct um Zugriffe für SmartVISU erweitert
+- item_attribut um pluggit_convert erweitert
+- scheduler.remove eingebaut
+
+29.08.2020:
+ - bool-Werte konnten nicht geschrieben werden
+
+## Folgende Vorteile ergeben sich zu dem Plugin 1.x
+
+- wesentlich mehr Parameter der pluggit können abgefragt werden
+- einige Parameter lassen sich auch schreiben
+- die Werte können intern auch konvertiert werden, sodass man eine vernünftige Ausgabe erhält
+
+## Es fehlen auch noch ein paar Dinge:
+
+- die Programmierung des Auto-Wochenprogramms ist noch nicht implementiert
+- eine Dokumentation der Parameter

--- a/pluggit/_pv_2_0_4/__init__.py
+++ b/pluggit/_pv_2_0_4/__init__.py
@@ -29,15 +29,23 @@ import threading
 import logging
 from lib.model.smartplugin import SmartPlugin
 
-# pymodbus library from https://github.com/pymodbus-dev/pymodbus
-from pymodbus.client.tcp import ModbusTcpClient
+# pymodbus library from https://github.com/riptideio/pymodbus
+from pymodbus.version import version
+pymodbus_baseversion = int(version.short().split('.')[0])
+
+if pymodbus_baseversion > 2:
+    # for newer versions of pymodbus
+    from pymodbus.client.tcp import ModbusTcpClient
+else:
+    # for older versions of pymodbus
+    from pymodbus.client.sync import ModbusTcpClient
 
 from pymodbus.constants import Endian
 from pymodbus.payload import BinaryPayloadDecoder
 from pymodbus.payload import BinaryPayloadBuilder
 
 class Pluggit(SmartPlugin):
-    PLUGIN_VERSION="2.0.6"
+    PLUGIN_VERSION="2.0.4"
 
     _itemReadDictionary = {}
     _itemWriteDictionary = {}
@@ -311,7 +319,6 @@ class Pluggit(SmartPlugin):
                 if pluggit_paramList[self.DICT_WRITE_ADDRESS] != -1:
                     # check for conditions
                     # unit mode = manual?
-                    self.logger.debug(f"Pluggit SendKey: {pluggit_sendkey}")
                     if pluggit_sendkey == 'prmRomIdxSpeedLevel':
                         self.SetUnitMode('UM_ManualMode', True)
                     # check for conversion
@@ -371,15 +378,15 @@ class Pluggit(SmartPlugin):
                 if unitstate != -1:
                     pluggit_paramList = self._modbusRegisterDictionary['prmRamIdxUnitMode']
                     registerValue = self._Pluggit.read_holding_registers(pluggit_paramList[self.DICT_READ_ADDRESS], pluggit_paramList[self.DICT_ADDRESS_QUANTITY])
-                    vdecoder = BinaryPayloadDecoder.fromRegisters(registerValue.registers, byteorder=Endian.BIG, wordorder=Endian.LITTLE)
+                    vdecoder = BinaryPayloadDecoder.fromRegisters(registerValue.registers, byteorder=Endian.Big, wordorder=Endian.Little)
                     readItemValue = vdecoder.decode_16bit_uint()
                     #if readItemValue & unitstate != unitstate:
                         # workaround for manual bypass timeout
+                    self.logger.info('SetUnitMode(): Mode \"{}\".'.format(modekey))
                         #if modekey == 'UM_ManualBypass' & bool(enable):
                             #self._Pluggit.write_registers(pluggit_paramList[self.DICT_WRITE_ADDRESS], unitmode[self.UM_DICT_VALUE_DISABLE])
                             #time.sleep(0.5)
                         # write value to registers
-                    self.logger.debug('SetUnitMode(): Mode \"{}\".'.format(modekey))
                     self._Pluggit.write_registers(pluggit_paramList[self.DICT_WRITE_ADDRESS], unitstate)
                     time.sleep(0.5)
             else:
@@ -465,7 +472,7 @@ class Pluggit(SmartPlugin):
                     registerValue = self._Pluggit.read_holding_registers(pluggit_paramList[self.DICT_READ_ADDRESS], pluggit_paramList[self.DICT_ADDRESS_QUANTITY])
                     # TODO: auswerten, wenn Reigister nicht auslesbar
                     readCacheDictionary[pluggit_key] = registerValue
-                vdecoder = BinaryPayloadDecoder.fromRegisters(registerValue.registers, byteorder=Endian.BIG, wordorder=Endian.LITTLE)
+                vdecoder = BinaryPayloadDecoder.fromRegisters(registerValue.registers, byteorder=Endian.Big, wordorder=Endian.Little)
 
                 readItemValue = None
                     

--- a/pluggit/_pv_2_0_4/pluggit.yaml
+++ b/pluggit/_pv_2_0_4/pluggit.yaml
@@ -1,0 +1,3 @@
+Zentral:
+    pluggit:
+        struct: pluggit.pluggit

--- a/pluggit/_pv_2_0_4/plugin.yaml
+++ b/pluggit/_pv_2_0_4/plugin.yaml
@@ -1,0 +1,640 @@
+# Metadata for the Smart-Plugin
+plugin:
+    # Global plugin attributes
+    type: interface                 # plugin type (gateway, interface, protocol, system, web)
+    description:
+        de: 'Anbindung einer KWL Pluggit AP310 über das Modbus-Protokoll.'
+        en: ''
+    maintainer: 'Cannon'
+#    tester:                        # Who tests this plugin?
+#    state:
+    keywords: modbus
+#    documentation:
+#    support:
+    version: 2.0.4                  # Plugin version
+    sh_minversion: 1.8              # minimum shNG version to use this plugin
+#    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
+    multi_instance: False           # plugin supports multi instance
+    classname: Pluggit              # class containing the plugin
+
+parameters:
+    # Definition of parameters to be configured in etc/plugin.yaml
+    host:
+        type: str
+        mandatory: True
+        description:
+            de: 'Hostname oder IP Adresse des Pluggit Dienstes.'
+            en: 'Hostname or IP address of the Pluggit service.'
+
+    port:
+        type: int
+        mandatory: False
+        default: 502
+        valid_min: 0
+        valid_max: 65535
+        description:
+            de: 'Port Nummer des Pluggit Dienstes.'
+            en: 'Port number of Pluggit service.'
+
+    cycle:
+        type: int
+        mandatory: False
+        default: 50
+        description:
+            de: 'Zykluszeit.'
+            en: 'Cycle time.'
+
+item_attributes:
+    # Definition of item attributes defined by this plugin
+    pluggit_read:
+        type: str
+        description:
+            de: 'Aus der Pluggit-Einheit zu lesende Daten.'
+            en: 'Data to be read from the Pluggit unit.'
+
+    pluggit_write:
+        type: str
+        description:
+            de: 'In die Pluggit-Einheit zu schreibender Wert.'
+            en: 'Value to be written to the Pluggit unit.'
+
+    pluggit_convert:
+        type: str
+        description:
+            de: 'Wandelt den gelesenen oder den zu schreibenden Wert in bzw. von ein anderes Format um.'
+            en: 'Convert the read or write to value to or from another format.'
+
+item_structs:
+    pluggit:
+        DHCPEnabled:
+            type: bool
+            pluggit_read: prmDHCPEN
+            visu_acl: ro
+
+        IPAdress:
+            type: str
+            pluggit_read: prmCurrentIPAddress
+            visu_acl: ro
+
+        IPMask:
+            type: str
+            pluggit_read: prmCurrentIPMask
+            visu_acl: ro
+
+        IPGateway:
+            type: str
+            pluggit_read: prmCurrentIPGateway
+            visu_acl: ro
+
+        MACAdress:
+            type: str
+            pluggit_read: prmMACAddr
+            visu_acl: ro
+
+        SystemComponents:
+            type: num
+            pluggit_read: prmSystemID
+            visu_acl: ro
+
+            FP1:
+                type: bool
+                pluggit_read: prmSystemID
+                pluggit_convert: SID_FP1
+                visu_acl: ro
+
+            Week:
+                type: bool
+                pluggit_read: prmSystemID
+                pluggit_convert: SID_Week
+                visu_acl: ro
+
+            Bypass:
+                type: bool
+                pluggit_read: prmSystemID
+                pluggit_convert: SID_Bypass
+                visu_acl: ro
+
+            LRSwitch:
+                type: bool
+                pluggit_read: prmSystemID
+                pluggit_convert: SID_LRSwitch
+                visu_acl: ro
+
+            InternalPreheater:
+                type: bool
+                pluggit_read: prmSystemID
+                pluggit_convert: SID_InternalPreheater
+                visu_acl: ro
+
+            ServoFlow:
+                type: bool
+                pluggit_read: prmSystemID
+                pluggit_convert: SID_ServoFlow
+                visu_acl: ro
+
+            RHSensor:
+                type: bool
+                pluggit_read: prmSystemID
+                pluggit_convert: SID_RHSensor
+                visu_acl: ro
+
+            VOCSensor:
+                type: bool
+                pluggit_read: prmSystemID
+                pluggit_convert: SID_VOCSensor
+                visu_acl: ro
+
+            ExtOverride:
+                type: bool
+                pluggit_read: prmSystemID
+                pluggit_convert: SID_ExtOverride
+                visu_acl: ro
+
+            HAC1:
+                type: bool
+                pluggit_read: prmSystemID
+                pluggit_convert: SID_HAC1
+                visu_acl: ro
+
+            HRC2:
+                type: bool
+                pluggit_read: prmSystemID
+                pluggit_convert: SID_HRC2
+                visu_acl: ro
+
+            PCTool:
+                type: bool
+                pluggit_read: prmSystemID
+                pluggit_convert: SID_PCTool
+                visu_acl: ro
+
+            Apps:
+                type: bool
+                pluggit_read: prmSystemID
+                pluggit_convert: SID_Apps
+                visu_acl: ro
+
+            ZeegBee:
+                type: bool
+                pluggit_read: prmSystemID
+                pluggit_convert: SID_ZeegBee
+                visu_acl: ro
+
+            DI1Override:
+                type: bool
+                pluggit_read: prmSystemID
+                pluggit_convert: SID_DI1Override
+                visu_acl: ro
+
+            DI2Override:
+                type: bool
+                pluggit_read: prmSystemID
+                pluggit_convert: SID_DI2Override
+                visu_acl: ro
+
+        SystemSerialNum:
+            type: num
+            pluggit_read: prmSystemSerialNum
+            visu_acl: ro
+
+        SystemName:
+            type: str
+            pluggit_read: prmSystemName
+            pluggit_write: prmSystemName
+            visu_acl: rw
+
+        SwitchInBPosition:
+            type: bool
+            pluggit_read: prmHALLeft
+            visu_acl: ro
+
+        SwitchInAPosition:
+            type: bool
+            pluggit_read: prmHALRight
+            visu_acl: ro
+
+        FirmwareVersion:
+            type: num
+            pluggit_read: prmFWVersion
+            visu_acl: ro
+
+        HACFirmwareVersion:
+            type: num
+            pluggit_read: prmRamIdxHac1FirmwareVersion
+            visu_acl: ro
+
+        SystemTime:
+            type: num
+            pluggit_read: prmDateTime
+            pluggit_write: prmDateTimeSet
+            visu_acl: rw
+
+            DateTime:
+                type: foo
+                pluggit_read: prmDateTime
+                pluggit_write: prmDateTimeSet
+                pluggit_convert: ToDateTime
+                visu_acl: rw
+
+            Date:
+                type: foo
+                pluggit_read: prmDateTime
+                pluggit_convert: ToDate
+                visu_acl: ro
+
+            Time:
+                type: foo
+                pluggit_read: prmDateTime
+                pluggit_convert: ToTime
+                visu_acl: ro
+
+        WorkTime:
+            type: num
+            pluggit_read: prmWorkTime
+            visu_acl: ro
+
+        ExploitationDate:
+            type: foo
+            pluggit_read: prmStartExploitationDateStamp
+            visu_acl: ro
+
+            Date:
+                type: foo
+                pluggit_read: prmStartExploitationDateStamp
+                pluggit_convert: ToDate
+                visu_acl: ro
+
+        BLState:
+            type: num
+            pluggit_read: prmCurrentBLState
+            visu_acl: ro
+
+            Text:
+                type: str
+                pluggit_read: prmCurrentBLState
+                pluggit_convert: ToString
+                visu_acl: ro
+
+        CurrentUnitMode:
+            type: num
+            pluggit_read: prmRamIdxUnitMode
+            pluggit_write: prmRamIdxUnitMode
+            visu_acl: rw
+
+            DemandMode:
+                type: bool
+                pluggit_read: prmRamIdxUnitMode
+                pluggit_write: prmRamIdxUnitMode
+                pluggit_convert: UM_DemandMode
+                visu_acl: rw
+
+            ManualMode:
+                type: bool
+                pluggit_read: prmRamIdxUnitMode
+                pluggit_write: prmRamIdxUnitMode
+                pluggit_convert: UM_ManualMode
+                visu_acl: rw
+
+            WeekProgramMode:
+                type: bool
+                pluggit_read: prmRamIdxUnitMode
+                pluggit_write: prmRamIdxUnitMode
+                pluggit_convert: UM_WeekProgramMode
+                visu_acl: rw
+
+            AwayMode:
+                type: bool
+                pluggit_read: prmRamIdxUnitMode
+                pluggit_write: prmRamIdxUnitMode
+                pluggit_convert: UM_AwayMode
+                visu_acl: rw
+
+            FireplaceMode:
+                type: bool
+                pluggit_read: prmRamIdxUnitMode
+                pluggit_write: prmRamIdxUnitMode
+                pluggit_convert: UM_FireplaceMode
+                visu_acl: rw
+
+            SummerMode:
+                type: bool
+                pluggit_read: prmRamIdxUnitMode
+                pluggit_write: prmRamIdxUnitMode
+                pluggit_convert: UM_SummerMode
+                visu_acl: rw
+
+            NightMode:
+                type: bool
+                pluggit_read: prmRamIdxUnitMode
+                pluggit_write: prmRamIdxUnitMode
+                pluggit_convert: UM_NightMode
+                visu_acl: rw
+
+                NightMode_StartHour:
+                    type: num
+                    pluggit_read: prmRomIdxNightModeStartHour
+                    pluggit_write: prmRomIdxNightModeStartHour
+                    visu_acl: rw
+
+                NightMode_StartMin:
+                    type: num
+                    pluggit_read: prmRomIdxNightModeStartMin
+                    pluggit_write: prmRomIdxNightModeStartMin
+                    visu_acl: rw
+
+                NightMode_EndHour:
+                    type: num
+                    pluggit_read: prmRomIdxNightModeEndHour
+                    pluggit_write: prmRomIdxNightModeEndHour
+                    visu_acl: rw
+
+                NightMode_EndMin:
+                    type: num
+                    pluggit_read: prmRomIdxNightModeEndMin
+                    pluggit_write: prmRomIdxNightModeEndMin
+                    visu_acl: rw
+
+            ManualBypass:
+                type: bool
+                pluggit_read: prmRamIdxUnitMode
+                pluggit_write: prmRamIdxUnitMode
+                pluggit_convert: UM_ManualBypass
+                visu_acl: rw
+
+        FanSpeedLevel:
+            type: num
+            pluggit_read: prmRomIdxSpeedLevel
+            pluggit_write: prmRomIdxSpeedLevel
+            visu_acl: rw
+
+        Fan1rpm:
+            type: num
+            pluggit_read: prmHALTaho1
+            visu_acl: ro
+
+        Fan2rpm:
+            type: num
+            pluggit_read: prmHALTaho2
+            visu_acl: ro
+
+        # Frischluft
+        OutdoorTemperature:
+            type: num
+            pluggit_read: prmRamIdxT1
+            visu_acl: ro
+
+        # Zuluft
+        SupplyTemperature:
+            type: num
+            pluggit_read: prmRamIdxT2
+            visu_acl: ro
+
+        # Abluft
+        ExtractTemperature:
+            type: num
+            pluggit_read: prmRamIdxT3
+            visu_acl: ro
+
+        # Fortluft
+        ExhaustTemperature:
+            type: num
+            pluggit_read: prmRamIdxT4
+            visu_acl: ro
+
+        # Raumtemperatur, kabellos
+        RoomTemperature:
+            type: num
+            pluggit_read: prmRamIdxT5
+            visu_acl: ro
+
+        FilterRemainingLifetime:
+            type: num
+            pluggit_read: prmFilterRemainingTime
+            visu_acl: ro
+
+        FilterDefaultTime:
+            type: num
+            pluggit_read: prmFilterDefaultTime
+            pluggit_write: prmFilterDefaultTime
+            visu_acl: rw
+
+        FilterReset:
+            type: bool
+            pluggit_read: prmFilterReset
+            pluggit_write: prmFilterReset
+            visu_acl: rw
+
+        Alarm:
+            type: num
+            pluggit_read: prmLastActiveAlarm
+            visu_acl: ro
+            Text:
+                type: str
+                pluggit_read: prmLastActiveAlarm
+                pluggit_convert: ToString
+                visu_acl: ro
+            ClearAlarm:
+                type: num
+                pluggit_write: prmSetAlarmNum
+                visu_acl: rw
+
+        WeekProgram:
+            type: num
+            pluggit_read: prmNumOfWeekProgram
+            pluggit_write: prmNumOfWeekProgram
+            visu_acl: rw
+
+            Monday:
+                type: list
+                pluggit_read: PrmWeekMon
+                pluggit_write: PrmWeekMon
+                visu_acl: rw
+
+            Tuesday:
+                type: list
+                pluggit_read: PrmWeekTue
+                pluggit_write: PrmWeekTue
+                visu_acl: rw
+
+            Wednesday:
+                type: list
+                pluggit_read: PrmWeekWed
+                pluggit_write: PrmWeekWed
+                visu_acl: rw
+
+            Thursday:
+                type: list
+                pluggit_read: PrmWeekThu
+                pluggit_write: PrmWeekThu
+                visu_acl: rw
+
+            Friday:
+                type: list
+                pluggit_read: PrmWeekFri
+                pluggit_write: PrmWeekFri
+                visu_acl: rw
+
+            Saturday:
+                type: list
+                pluggit_read: PrmWeekSat
+                pluggit_write: PrmWeekSat
+                visu_acl: rw
+
+            Sunday:
+                type: list
+                pluggit_read: PrmWeekSun
+                pluggit_write: PrmWeekSun
+                visu_acl: rw
+
+        Bypass:
+            type: num
+            pluggit_read: prmRamIdxBypassActualState
+            visu_acl: ro
+
+            Text:
+                type: str
+                pluggit_read: prmRamIdxBypassActualState
+                pluggit_convert: ToString
+                visu_acl: ro
+
+            Open:
+                type: bool
+                pluggit_read: prmRamIdxBypassActualState
+                pluggit_convert: ToBool
+                visu_acl: ro
+
+            Tmin:
+                type: num
+                pluggit_read: prmBypassTmin
+                visu_acl: ro
+
+            Tmax:
+                type: num
+                pluggit_read: prmBypassTmax
+                visu_acl: ro
+
+            ManualMode:
+                type: bool
+                enforce_updates: yes
+                pluggit_read: prmRamIdxUnitMode
+                pluggit_write: prmRamIdxUnitMode
+                pluggit_convert: UM_ManualBypass
+                visu_acl: rw
+
+            ManualTimeout:
+                type: num
+                pluggit_read: prmRamIdxBypassManualTimeout
+                visu_acl: ro
+
+        PreheaterPower:
+            type: num
+            pluggit_read: prmPreheaterDutyCycle
+            visu_acl: ro
+
+        ReferenceExtractFanSpeed:
+            type: num
+            pluggit_read: prmRefValEx
+            visu_acl: ro
+
+        ReferenceSupplyFanSpeed:
+            type: num
+            pluggit_read: prmRefValSupl
+            visu_acl: ro
+
+        FireplacePresent:
+            type: bool
+            pluggit_read: prmFireplacePreset
+            visu_acl: ro
+
+        VOC_Sensor:
+            SensorValue:
+                type: num
+                pluggit_read: prmVOC
+                visu_acl: ro
+
+            LowTreshold:
+                type: num
+                pluggit_read: prmPPM1Unit
+                pluggit_write: prmPPM1Unit
+                visu_acl: rw
+
+            MiddleTreshold:
+                type: num
+                pluggit_read: prmPPM2Unit
+                pluggit_write: prmPPM2Unit
+                visu_acl: rw
+
+            HighTreshold:
+                type: num
+                pluggit_read: prmPPM3Unit
+                pluggit_write: prmPPM3Unit
+                visu_acl: rw
+
+        RH_Sensor:
+            SensorValue:
+                type: num
+                pluggit_read: prmRamIdxRh3Corrected
+                visu_acl: ro
+
+            SetPoint:
+                type: num
+                pluggit_read: prmRomIdxRhSetPoint
+                visu_acl: ro
+
+        HAC_Parts:
+            SystemIDComponents:
+                type: num
+                pluggit_read: prmSystemIDComponents
+                visu_acl: ro
+
+            CO2_Level:
+                type: num
+                pluggit_read: prmHACCO2Val
+                visu_acl: ro
+
+            CO2_LowTreshold:
+                type: num
+                pluggit_read: prmPPM1External
+                pluggit_write: prmPPM1External
+                visu_acl: rw
+
+            CO2_MiddleTreshold:
+                type: num
+                pluggit_read: prmPPM2External
+                pluggit_write: prmPPM2External
+                visu_acl: rw
+
+            CO2_HighTreshold:
+                type: num
+                pluggit_read: prmPPM3External
+                pluggit_write: prmPPM3External
+                visu_acl: rw
+
+            IdxHac1Components:
+                type: num
+                pluggit_read: prmRamIdxHac1Components
+                visu_acl: ro
+
+            SetpointT2:
+                type: num
+                pluggit_read: prmRomIdxAfterHeaterT2SetPoint
+                pluggit_write: prmRomIdxAfterHeaterT2SetPoint
+                visu_acl: rw
+
+            SetpointT3:
+                type: num
+                pluggit_read: prmRomIdxAfterHeaterT3SetPoint
+                pluggit_write: prmRomIdxAfterHeaterT3SetPoint
+                visu_acl: rw
+
+            SetpointT5:
+                type: num
+                pluggit_read: prmRomIdxAfterHeaterT5SetPoint
+                pluggit_write: prmRomIdxAfterHeaterT5SetPoint
+                visu_acl: rw
+
+logic_parameters: NONE
+    # Definition of logic parameters defined by this plugin
+
+plugin_functions:
+    # Definition of function interface of the plugin

--- a/pluggit/_pv_2_0_4/requirements.txt
+++ b/pluggit/_pv_2_0_4/requirements.txt
@@ -1,0 +1,2 @@
+pymodbus>=2.3,<3.0;python_version<'3.8'
+pymodbus>=3.0.2;python_version>="3.8"

--- a/pluggit/_pv_2_0_4/user_doc.rst
+++ b/pluggit/_pv_2_0_4/user_doc.rst
@@ -1,0 +1,128 @@
+
+.. index:: Plugins; pluggit
+.. index:: pluggit Plugin
+
+=======
+pluggit
+=======
+
+.. image:: webif/static/img/plugin_logo.svg
+   :alt: plugin logo
+   :width: 300px
+   :height: 300px
+   :scale: 50 %
+   :align: left
+
+Das pluggit plugin dient zur Ansteuerung einer Pluggit AP310 KWL.
+
+
+Einführung
+==========
+
+Die aktuelle Version 2.x des Plugins ist eine Neuentwicklung auf Basis der Version v1.2.3 des pluggit Plugins.
+Die Version 2.x ist nicht konfigurations-kompatibel zur Version 1.x. Die Konfiguration der Plugin Parameter und der
+Item Attribute ist daher neu entsprechend der aktuellen Dokumentation vorzunehmen.
+
+Es ist bei Bedarf jedoch möglich erstmal die alte Version v1.2.3 des pluggit Plugins weiter zu nutzen.
+Dazu muss nur ein Eintrag in der Plugin Konfiguration in der etc/plugin.yaml angepasst/eingefügt werden.
+
+Statt
+
+.. code:: yaml
+
+    pluggit:
+        plugin_name: pluggit
+
+        ...
+
+
+muss die zu verwendende Version des Plugins zusätzlich angegeben werden:
+
+.. code:: yaml
+
+    pluggit:
+        plugin_name: pluggit
+        plugin_version: 1.2.3
+
+        ...
+
+
+Vorteile gegenüber der Plugin Version v1.2.3
+============================================
+
+- wesentlich mehr Parameter der pluggit können abgefragt werden
+- einige Parameter lassen sich auch schreiben
+- die Werte können intern auch konvertiert werden, sodass man eine vernünftige Ausgabe erhält
+
+
+Es fehlen auch noch ein paar Dinge
+==================================
+
+- die Programmierung des Auto-Wochenprogramms ist noch nicht implementiert
+- eine Dokumentation der Parameter
+
+
+.. Anforderungen
+.. =============
+
+.. Anforderungen des Plugins auflisten. Werden spezielle Soft- oder Hardwarekomponenten benötigt?
+
+.. Um das Plugin zu nutzen, muss ...
+
+
+.. Installation benötigter Software
+.. ================================
+
+Konfiguration
+=============
+
+Die Plugin Parameter und die Informationen zur Item-spezifischen Konfiguration des Plugins sind
+unter :doc:`/plugins_doc/config/pluggit` nachzulesen.
+
+
+Struct
+======
+
+Die zur Nutzung des Plugins benötigten Items können durch die Einbindung der struct **pluggit.pluggit** angelegt
+werden.
+
+
+.. Beispiele
+.. ---------
+
+.. Hier können ausführlichere Beispiele und Anwendungsfälle beschrieben werden.
+
+
+.. Web Interface
+.. =============
+
+.. ...
+
+
+Version History
+===============
+
+V2.0.3 - 25.10.2022
+
+- Support für pymodbus 3.0
+
+22.05.2022
+
+- Fehler mit manuellem Bypass behoben
+
+16.02.2022
+
+- CurentUnitMode.ManualBypass dem Item-struct zugefügt
+- Log-Level für verschiedene Ausgaben angepasst
+- CurrentUnitMode.AwayMode repariert
+
+24.02.2021
+
+- Item-struct um Zugriffe für SmartVISU erweitert
+- item_attribut um pluggit_convert erweitert
+- scheduler.remove eingebaut
+
+29.08.2020
+
+ - bool-Werte konnten nicht geschrieben werden
+

--- a/pluggit/changes.txt
+++ b/pluggit/changes.txt
@@ -1,0 +1,8 @@
+15.09.2023:
+- Anpassung für pymodbus 3.5.2: bytorder und wordorder musste korrrigiert werden, statt Little und Big nun LITTLE und BIG
+
+11.09.2023:
+- unter Python 10 muss mindestens die Version 3.3.2 von pymodbus laufen, da sonst Verbindungsprobleme
+
+23.07.2023:
+- pymodbus mindestens Version 3.3.0, da Versionsmanagement geändert wurde, Version 2 wird nicht mehr unterstützt

--- a/pluggit/plugin.yaml
+++ b/pluggit/plugin.yaml
@@ -11,7 +11,7 @@ plugin:
     keywords: modbus
 #    documentation:
 #    support:
-    version: 2.0.4                  # Plugin version
+    version: 2.0.6                  # Plugin version
     sh_minversion: 1.8              # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False           # plugin supports multi instance

--- a/pluggit/requirements.txt
+++ b/pluggit/requirements.txt
@@ -1,2 +1,1 @@
-pymodbus>=2.3,<3.0;python_version<'3.8'
-pymodbus>=3.0.2;python_version>="3.8"
+pymodbus>=3.5.2;python_version>='3.8'

--- a/pluggit/user_doc.rst
+++ b/pluggit/user_doc.rst
@@ -102,27 +102,32 @@ werden.
 Version History
 ===============
 
-V2.0.3 - 25.10.2022
+V2.0.6 - 15.09.2023
+- Anpassung für pymodbus 3.5.2: bytorder und wordorder musste korrrigiert werden, statt Little und Big nun LITTLE und BIG
+- Python muss >= 3.8 sein und pymodbus >= 3.5.2
 
+V2.0.5 - 11.09.2023
+- unter Python 10 muss mindestens die Version 3.3.2 von pymodbus laufen, da sonst Verbindungsprobleme
+
+V2.0.4 - 13.11.2022
+- Verbesserungen zur Versionsprüfung "pymodbus"
+
+V2.0.3 - 25.10.2022
 - Support für pymodbus 3.0
 
 22.05.2022
-
 - Fehler mit manuellem Bypass behoben
 
 16.02.2022
-
 - CurentUnitMode.ManualBypass dem Item-struct zugefügt
 - Log-Level für verschiedene Ausgaben angepasst
 - CurrentUnitMode.AwayMode repariert
 
 24.02.2021
-
 - Item-struct um Zugriffe für SmartVISU erweitert
 - item_attribut um pluggit_convert erweitert
 - scheduler.remove eingebaut
 
 29.08.2020
-
  - bool-Werte konnten nicht geschrieben werden
 

--- a/pluggit/user_doc.rst
+++ b/pluggit/user_doc.rst
@@ -137,5 +137,5 @@ V2.0.3 - 25.10.2022
 
 29.08.2020
 
- - bool-Werte konnten nicht geschrieben werden
+- bool-Werte konnten nicht geschrieben werden
 

--- a/pluggit/user_doc.rst
+++ b/pluggit/user_doc.rst
@@ -103,31 +103,39 @@ Version History
 ===============
 
 V2.0.6 - 15.09.2023
+
 - Anpassung für pymodbus 3.5.2: bytorder und wordorder musste korrrigiert werden, statt Little und Big nun LITTLE und BIG
 - Python muss >= 3.8 sein und pymodbus >= 3.5.2
 
 V2.0.5 - 11.09.2023
+
 - unter Python 10 muss mindestens die Version 3.3.2 von pymodbus laufen, da sonst Verbindungsprobleme
 
 V2.0.4 - 13.11.2022
+
 - Verbesserungen zur Versionsprüfung "pymodbus"
 
 V2.0.3 - 25.10.2022
+
 - Support für pymodbus 3.0
 
 22.05.2022
+
 - Fehler mit manuellem Bypass behoben
 
 16.02.2022
+
 - CurentUnitMode.ManualBypass dem Item-struct zugefügt
 - Log-Level für verschiedene Ausgaben angepasst
 - CurrentUnitMode.AwayMode repariert
 
 24.02.2021
+
 - Item-struct um Zugriffe für SmartVISU erweitert
 - item_attribut um pluggit_convert erweitert
 - scheduler.remove eingebaut
 
 29.08.2020
+
  - bool-Werte konnten nicht geschrieben werden
 


### PR DESCRIPTION
- Support für pymodbus 2 entfernt
- getestet und lauffähig unter Python 3.9. und 3.10