### PR TITLE
homematic: fixing WebInterface for items with the same name

### DIFF
--- a/homematic/__init__.py
+++ b/homematic/__init__.py
@@ -237,7 +237,7 @@ class Homematic(SmartPlugin):
                 hm_node = None
 
             # store item and device information for plugin instance
-            self.hm_items.append( [str(item), item, hm_address, hm_channel, hm_function, hm_node, dev_type] )
+            self.hm_items.append( [str(item.id()), item, hm_address, hm_channel, hm_function, hm_node, dev_type] )
 
             # Initialize item from HomeMatic
             if dev is not None:

--- a/homematic/__init__.py
+++ b/homematic/__init__.py
@@ -237,7 +237,7 @@ class Homematic(SmartPlugin):
                 hm_node = None
 
             # store item and device information for plugin instance
-            self.hm_items.append( [str(item.id()), item, hm_address, hm_channel, hm_function, hm_node, dev_type] )
+            self.hm_items.append( [str(item.property.path), item, hm_address, hm_channel, hm_function, hm_node, dev_type] )
 
             # Initialize item from HomeMatic
             if dev is not None:


### PR DESCRIPTION
2024-02-24  23:02:35 ERROR    cherrypy.error.140734358467536 [24/Feb/2024:23:02:35] HTTP 
> Traceback (most recent call last):
>   File "/usr/local/lib/python3.10/site-packages/cherrypy/_cprequest.py", line 638, in respond
>     self._do_respond(path_info)
>   File "/usr/local/lib/python3.10/site-packages/cherrypy/_cprequest.py", line 697, in _do_respond
>     response.body = self.handler()
>   File "/usr/local/lib/python3.10/site-packages/cherrypy/lib/encoding.py", line 223, in __call__
>     self.body = self.oldhandler(*args, **kwargs)
>   File "/usr/local/lib/python3.10/site-packages/cherrypy/_cpdispatch.py", line 54, in __call__
>     return self.callable(*self.args, **self.kwargs)
>   File "/usr/local/smarthome/plugins/homematic/__init__.py", line 556, in index
>     items=sorted(self.plugin.hm_items), item_count=len(self.plugin.hm_items),
> TypeError: '<' not supported between instances of 'Item' and 'Item'