### PR TITLE
[modbus_tcp plugin]: fixed error writing registers, conversion byte/word to endian

### DIFF
--- a/modbus_tcp/plugin.yaml
+++ b/modbus_tcp/plugin.yaml
@@ -11,7 +11,7 @@ plugin:
     keywords: modbus_tcp modbus smartmeter inverter heatpump
     #documentation: http://smarthomeng.de/user/plugins/modbus_tcp/user_doc.html
     support: https://knx-user-forum.de/forum/supportforen/smarthome-py/1154368-einbindung-von-modbus-tcp
-    version: 1.0.10                # Plugin version
+    version: 1.0.11                # Plugin version
     sh_minversion: 1.8             # minimum shNG version to use this plugin
     #sh_maxversion:                # maximum shNG version to use this plugin (leave empty if latest)
     py_minversion: 3.6
@@ -102,23 +102,23 @@ item_attributes:
 
     modBusByteOrder:
         type: str
-        default: 'Endian.Big'
+        default: 'Endian.BIG'
         description:
-            de: 'Endian.Big oder Endian.Little'
-            en: 'Endian.Big or Endian.Little'
+            de: 'Endian.BIG oder Endian.LITTLE'
+            en: 'Endian.BIG or Endian.LITTLE'
         valid_list:
-            - 'Endian.Big'
-            - 'Endian.Little'
+            - 'Endian.BIG'
+            - 'Endian.LITTLE'
 
     modBusWordOrder:
         type: str
-        default: 'Endian.Big'
+        default: 'Endian.BIG'
         description:
-            de: 'Endian.Big oder Endian.Little'
-            en: 'Endian.Big or Endian.Little'
+            de: 'Endian.BIG oder Endian.LITTLE'
+            en: 'Endian.BIG or Endian.LITTLE'
         valid_list:
-            - 'Endian.Big'
-            - 'Endian.Little'
+            - 'Endian.BIG'
+            - 'Endian.LITTLE'
 
     modBusFactor:
         type: num

--- a/modbus_tcp/user_doc.rst
+++ b/modbus_tcp/user_doc.rst
@@ -164,6 +164,9 @@ siehe auch example.yaml
 
 Changelog
 ---------
+V1.0.11	Verbesserung Umwandlung Byte/Wordorder in Endian-Konstante
+        Fehler beim Schreiben von Register behoben
+
 V1.0.10	Mindestversion für pymodbus ist nun 3.5.2
 
 V1.0.9  


### PR DESCRIPTION
Error when writing registers fixed
Improved conversion of byte/word order to endian constant