### PR TITLE
solarforecast: add hourly forecast and power checks

### DIFF
--- a/solarforecast/__init__.py
+++ b/solarforecast/__init__.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 # vim: set encoding=utf-8 tabstop=4 softtabstop=4 shiftwidth=4 expandtab
 #########################################################################
-#  Copyright 2022 Alexander Schwithal 
+#  Copyright 2022 Alexander Schwithal
 #########################################################################
-#  This file is part of SmartHomeNG.   
+#  This file is part of SmartHomeNG.
 #
 #  Solarforecast plugin
 #
@@ -22,22 +22,26 @@
 #
 #########################################################################
 
-from lib.model.smartplugin import *
-from lib.item import Items
+from lib.model.smartplugin import SmartPlugin
 from .webif import WebInterface
 
 import requests
-import json
 import datetime
+
+SERVICES = ['solarforecast']
+
+# provide for locally cached data to prevent online requests while testing. Do not use.
+TESTING = False
+# TESTING = True
+DUMMY = {}
 
 
 class Solarforecast(SmartPlugin):
-    PLUGIN_VERSION = '1.9.4'
+    PLUGIN_VERSION = '1.9.5'
 
     def __init__(self, sh):
         """
         Initalizes the plugin.
-
         """
 
         # Call init code of parent class (SmartPlugin)
@@ -45,16 +49,17 @@ class Solarforecast(SmartPlugin):
 
         self._sh = sh
         self._cycle = 7200
-        self.session = requests.Session()
-        
+        self.json = {}
+
         # get the parameters for the plugin (as defined in metadata plugin.yaml):
-        if self.get_parameter_value('latitude') != 0 and self.get_parameter_value('longitude') != 0:
-            self.latitude = self.get_parameter_value('latitude')
-            self.longitude = self.get_parameter_value('longitude')
-        else:
-            self.logger.debug("__init__: latitude and longitude not provided, using shng system values instead.")
-            self.latitude = self.get_sh()._lat
-            self.longitude = self.get_sh()._lon
+        self.latitude = self.get_parameter_value('latitude')
+        self.longitude = self.get_parameter_value('longitude')
+
+        # hopefully, we don't have users using this off Africas western coast... ;-)
+        if self.latitude == self.longitude == 0.0:
+            self.latitude = self._sh._lat
+            self.longitude = self._sh._lon
+            self.logger.debug("latitude and longitude not provided, using shng system values instead.")
 
         self.declination = self.get_parameter_value('declination')
         self.azimuth = self.get_parameter_value('azimuth')
@@ -62,119 +67,112 @@ class Solarforecast(SmartPlugin):
         self.service = self.get_parameter_value('service')
         self.webif_pagelength = self.get_parameter_value('webif_pagelength')
 
-        if self.latitude is None or \
-                self.longitude is None or \
-                self.declination is None or \
-                self.azimuth is None or \
-                self.kwp is None:
-            self.logger.error("Plugin needs valid latitude, longitude, declination, azimuth and kwp values")
+        # Note: as plugin.yaml makes providing parameters mandatory, they cannot be None anymore
 
-        if self.service != 'solarforecast':
+        if self.service not in SERVICES:
             self.logger.error(f"Service {self.service} is not supported yet.")
-        
+            self._init_complete = False
+            return
+
         self.logger.debug("Init completed.")
         self.init_webinterface(WebInterface)
-        self._items = {}
-        return
 
     def run(self):
-        #self.logger.debug("Run method called")
+        self.logger.debug("Run method called")
         self.scheduler_add('poll_backend', self.poll_backend, prio=5, cycle=self._cycle)
         self.alive = True
-        #self.poll_backend()
 
     def stop(self):
-        self.scheduler_remove('poll_backend')
-        #self.logger.debug("Stop method called")
+        self.logger.debug("Stop method called")
         self.alive = False
+        self.scheduler_remove('poll_backend')
 
     def parse_item(self, item):
-        
         """
         Default plugin parse_item method. Is called when the plugin is initialized. Selects each item corresponding to
-        the neato_attribute and adds it to an internal array
+        the solarforecast_attribute and adds it to an internal array
 
         :param item: The item to process.
         """
+        super().parse_item(item)
+
         if self.get_iattr_value(item.conf, 'solarforecast_attribute'):
-            if not self.get_iattr_value(item.conf, 'solarforecast_attribute') in self._items:
-                self._items[self.get_iattr_value(item.conf, 'solarforecast_attribute')] = []
-            self._items[self.get_iattr_value(item.conf, 'solarforecast_attribute')].append(item)
-#            self.logger.debug(f"Appending item {item.property.path}")
+            # add_item automatically adds to self._plg_item_dict and self._item_lookup_dict
+            # the last one is equal to old self._items, but supports (later) item removal
+            self.add_item(item, mapping=self.get_iattr_value(item.conf, 'solarforecast_attribute'))
 
+    def _get_json(self, url):
 
-    def parse_logic(self, logic):
-            pass
+        if TESTING and url in DUMMY:
 
-    def update_item(self, item, caller=None, source=None, dest=None):
-        pass
+            # for testing, use cached responses to prevent frequent polling of service
+            self.logger.debug('using dummy response for request url')
+            self.json = DUMMY[url]
+        else:
+            try:
+                response = requests.get(
+                    url, headers={'content-type': 'application/json'}, timeout=10, verify=False)
 
+            except requests.exceptions.Timeout as e:
+                self.logger.warning(f"Timeout exception during get command: {e}")
+                return
+            except Exception as e:
+                self.logger.error(f"Exception during get command: {e}")
+                return
+
+            statusCode = response.status_code
+            if statusCode == 200:
+                self.logger.debug("Sending session request command successful")
+            else:
+                self.logger.error(f"Server error: {statusCode}")
+                return
+
+            try:
+                self.json = response.json()
+            except Exception as e:
+                self.logger.error(f"Exception during json decoding: {str(e)}")
+                self.json = {}
+                return
 
     def poll_backend(self):
 
-        self.logger.debug(f"polling backend...")
+        if not self.alive:
+            return
+
+        self.logger.debug("polling backend...")
+
         urlService = 'https://api.forecast.solar/estimate/'
-        functionURL = '{0}/{1}/{2}/{3}/{4}'.format(self.latitude,self.longitude,self.declination,self.azimuth,self.kwp)
+        functionURL = f'{self.latitude}/{self.longitude}/{self.declination}/{self.azimuth}/{self.kwp}'
 
-        #self.logger.debug(f"DEBUG URL: {urlService + functionURL}")
+        self.logger.debug(f"DEBUG URL: {urlService + functionURL}")
 
-        try:
-            sessionrequest_response = self.session.get(
-                urlService + functionURL, 
-                headers={'content-type': 'application/json'}, timeout=10, verify=False)
-        
-#            self.logger.debug(f"Session request response: {sessionrequest_response.text}")
-        except requests.exceptions.Timeout as e:
-            self.logger.warning(f"Timeout exception during get command: {str(e)}")
-            return 
-        except Exception as e:
-            self.logger.error(f"Exception during get command: {str(e)}")
-            return
+        # fetch json data
+        self._get_json(urlService + functionURL)
 
-        statusCode = sessionrequest_response.status_code
-        if statusCode == 200:
-            self.logger.debug("Sending session request command successful")
-            pass
-        else:
-            self.logger.error(f"Server error: {statusCode}")
-            return 
+        self.logger.debug(f"Json response: {self.json}")
 
-        try:
-            responseJson = sessionrequest_response.json()
-        except Exception as e:
-            self.logger.error(f"Exception during json decoding: {str(e)}")
-            return
-
-        self.logger.debug(f"Json response: {responseJson}")
-        
-        # Decode Json data:        
+        # Decode Json data:
         wattHoursToday = None
         wattHoursTomorrow = None
         today = self._sh.shtime.now().date()
         tomorrow = today + datetime.timedelta(days=1)
         self.last_update = today
 
-        if responseJson:
-            if 'result' in responseJson:
-                resultJson = responseJson['result']
-                if 'watt_hours_day' in resultJson:
-                    wattHoursJson = resultJson['watt_hours_day']
- #                   self.logger.debug(f"wattHourJson: {wattHoursJson}")
-        
-                    if str(today) in wattHoursJson:
-                        wattHoursToday = float(wattHoursJson[str(today)])
-                    if str(tomorrow) in wattHoursJson:
-                        wattHoursTomorrow = float(wattHoursJson[str(tomorrow)])
-#                   self.logger.debug(f"Ertrag today {wattHoursToday/1000} kWh, tomorrow: {wattHoursTomorrow/1000} kwH")
+        if not self.json or 'result' not in self.json:
+            return
 
+        resultJson = self.json['result']
+        if 'watt_hours_day' in resultJson:
+            wattHoursJson = resultJson['watt_hours_day']
+            # self.logger.debug(f"wattHourJson: {wattHoursJson}")
+            if str(today) in wattHoursJson:
+                wattHoursToday = float(wattHoursJson[str(today)])
+            if str(tomorrow) in wattHoursJson:
+                wattHoursTomorrow = float(wattHoursJson[str(tomorrow)])
+            # self.logger.debug(f"Ertrag today {wattHoursToday/1000} kWh, tomorrow: {wattHoursTomorrow/1000} kwH")
 
-        for attribute, matchStringItems in self._items.items():
-
-            if not self.alive:
-                return
-
-#            self.logger.warning("DEBUG: attribute: {0}, matchStringItems: {1}".format(attribute, matchStringItems))
-
+        # check all attributes...
+        for attribute, items in self._item_lookup_dict.items():
             value = None
 
             if attribute == 'energy_today':
@@ -185,19 +183,60 @@ class Solarforecast(SmartPlugin):
                 value = str(today)
             elif attribute == 'date_tomorrow':
                 value = str(tomorrow)
-            
-            # if a value was found, store it to item
+            elif attribute == 'watts_hourly':
+
+                # recalculate values for easier use
+                now = self._sh.shtime.now()
+                datestr = str(now.date())
+
+                # {hour0: watts, hour1: watts, hour2: watts...}
+                value = {int(k[11:13]): self.json['result']['watts'][k] for k in sorted(self.json['result']['watts'].keys()) if k.startswith(datestr)}
+
+            # if a value was found, store it to item(s)
             if value is not None:
-                for sameMatchStringItem in matchStringItems:
-                    sameMatchStringItem(value, self.get_shortname() )
-                    self.logger.debug('_update: Value "{0}" written to item {1}'.format(value, sameMatchStringItem))
-        pass
+                for item in items:
+                    item(value, self.get_shortname())
+                    self.logger.debug(f'Value "{value}" written to item {item}')
 
-    def get_items(self):
-        return self._items
-  
+    def is_power_available(self, power, hours):
+        """
+        This function should return a boolean value indicating if the requested
+        power is estimated to be available for the next given number of hours.
+        The current hour is counted, but to keep it simple, the given number of 
+        hours are counten from the next full hour, so we count to "now + hours + 1".
 
+        As errors cannot properly be handled in eval call stacks, we return False
+        for every error, as there might be
+        - server error, parameter error, timout, auth error (public limits)
+        - json error, data error
+        - connection error
+        - plugin not running
 
+        :param power: watts requested
+        :ptype power: int
+        :param hours: number of hours requested
+        :ptype hours: int
 
+        :return: True if power is estimated to be available, False else
+        :rtype: bool
+        """
 
+        if not self.json:
+            try:
+                self.poll_backend()
+            except Exception:
+                return False
 
+        # exceptions not appropriate for eval...
+        if not self.json:
+            return False
+
+        # see self.poll_backend()
+        datestr = str(self._sh.shtime.now().date())
+        watts = {int(k[11:13]): self.json['result']['watts'][k] for k in sorted(self.json['result']['watts'].keys()) if k.startswith(datestr)}
+
+        for hour in range(self.now().hour, self.now().hour + hours + 1):
+            if watts.get(hour, 0) < power:
+                return False
+
+        return True

--- a/solarforecast/plugin.yaml
+++ b/solarforecast/plugin.yaml
@@ -6,24 +6,22 @@ plugin:
         de: 'Plugin zur Anbindung an eine Web-basierte Solaretragsvorhersage'
         en: 'Plugin to connect to a web-based solar forecast service'
     maintainer: Alexander Schwithal (aschwith)
-    tester: henfri, Haiphong
-    state: develop                  # change to ready when done with development
+    tester: henfri, Haiphong, Morg42
+    state: development                  # change to ready when done with development
     keywords: solar.forecast, solar
 #    documentation:
     support: https://knx-user-forum.de/forum/supportforen/smarthome-py/1842817-support-thread-f%C3%BCr-das-solarforecast-plugin
 
-    version: 1.9.4                  # Plugin version
-    sh_minversion: 1.8.0            # minimum shNG version to use this plugin
+    version: 1.9.5                  # Plugin version
+    sh_minversion: 1.10.0            # minimum shNG version to use this plugin
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
-    multi_instance: True            # plugin supports multi instance
-    restartable: unknown
+    multi_instance: true            # plugin supports multi instance
+    restartable: true
     classname: Solarforecast        # class containing the plugin
 
 parameters:
     latitude:
         type: num
-        mandatory: False
-        default: 0.0
         valid_min: -90
         valid_max: 90
         description:
@@ -31,8 +29,6 @@ parameters:
             en: '(Optional) Latitude of solar system in decimal degree. Otherwise taken from smarthome config.'
     longitude:
         type: num
-        mandatory: False
-        default: 0.0
         valid_min: -180
         valid_max: 180
         description:
@@ -40,7 +36,7 @@ parameters:
             en: '(Optional) Longitude of solar system in decimal degree. Otherwise taken from smarthome config.'
     declination:
         type: num
-        mandatory: True
+        mandatory: true
         valid_min: 0
         valid_max: 90
         description:
@@ -48,7 +44,7 @@ parameters:
             en: 'Panel declination in degree'
     azimuth:
         type: num
-        mandatory: True
+        mandatory: true
         valid_min: -180
         valid_max: 180
         description:
@@ -56,11 +52,12 @@ parameters:
             en: 'Azimuth angle of panel direction (-180 to 180 degrees). 0 degree is equivalent to southern direction, (-180 = north, -90 = east, 0 = south, 90 = west, 180 = north)'
     kwp:
         type: num
-        mandatory: True
+        mandatory: true
         valid_min: 0
         description:
             de: 'Leistung der Solaranlage in kW Peak'
             en: 'Power of solar system in kw peak'
+
     service:
         type: str
         default: 'solarforecast'
@@ -75,7 +72,6 @@ parameters:
 
 
 item_attributes:
-    # Definition of item attributes defined by this plugin (enter 'item_attributes: NONE', if section should be empty)
     solarforecast_attribute:
         type: str
         description:
@@ -83,26 +79,621 @@ item_attributes:
                  Vorhersage Energie in Wh morgen
                  Vorhersage Energie in Wh heute
                  Datum morgen
-                 Datum heute'
+                 Datum heute
+                 stündliche Vorhersage und Leistungchecks'
             en: 'Solarforecast attributes:
                  Forecast energy in Wh tomorrow
                  Forecast energy in Wh today
                  Date tomorrow
-                 Date today'
+                 Date today
+                 Hourly forecast and power checks'
         valid_list:
           - energy_tomorrow
           - energy_today
           - date_tomorrow
           - date_today
+          - watts_hourly
 
-item_structs: NONE
-    # Definition of item-structure templates for this plugin (enter 'item_structs: NONE', if section should be empty)
-    #item_structs: NONE
+plugin_functions:
+    is_power_available:
+        description:
+            de: 'Prüft, ob die angegebene Leistung für die angegebene Zahl an Stunden voraussichtlich erreicht wird'
+            en: 'Checks if given power is estimated to be produces for the given number of hours'
+        type: bool
+        parameters:
+            power:
+                type: int
+                valid_min: 0
+                description:
+                    de: 'Geforderte Leistung in Watt'
+                    en: 'Requested power in watts'
+            hours:
+                type: int
+                default: 2
+                valid_min: 1
+                description:
+                    de: 'Geforderte Anzahl an Stunden ab jetzt bzw. der nächsten vollen Stunde'
+                    en: 'Requested number of hours from now respective from the next full hour'
 
-plugin_functions: NONE
+item_structs:
+    hourly:
+        type: dict
+        solarforecast_attribute: watts_hourly
+        enforce_updates: true
+
+        data_hour:
+            type: num
+            eval: sh...self.property.last_update.hour
+            eval_trigger: ..
+
+        hours:
+
+            h0:
+                remark: data for current hour (in reference to data_hour)
+                type: num
+                eval: sh....dict.get(sh....data_hour(), 0)
+                eval_trigger: ...
+
+                g5:
+                    remark: flag if produced solar power is estimated to be more than 500 watts
+                    type: bool
+                    eval: sh...() > 500
+                    eval_trigger: ..
+
+                g10:
+                    remark: flag if produced solar power is estimated to be more than 1000 watts
+                    type: bool
+                    eval: sh...() > 1000
+                    eval_trigger: ..
+
+                g15:
+                    remark: flag if produced solar power is estimated to be more than 1500 watts
+                    type: bool
+                    eval: sh...() > 1500
+                    eval_trigger: ..
+
+                g20:
+                    remark: flag if produced solar power is estimated to be more than 2000 watts
+                    type: bool
+                    eval: sh...() > 2000
+                    eval_trigger: ..
+
+                g25:
+                    remark: flag if produced solar power is estimated to be more than 2500 watts
+                    type: bool
+                    eval: sh...() > 2500
+                    eval_trigger: ..
+
+                g30:
+                    remark: flag if produced solar power is estimated to be more than 3000 watts
+                    type: bool
+                    eval: sh...() > 3000
+                    eval_trigger: ..
+
+                g35:
+                    remark: flag if produced solar power is estimated to be more than 3500 watts
+                    type: bool
+                    eval: sh...() > 3500
+                    eval_trigger: ..
+
+            h1:
+                remark: data for current hour + 1 (in reference to data_hour)
+                type: num
+                eval: sh....dict.get(sh....data_hour() + 1, 0)
+                eval_trigger: ...
+
+                g5:
+                    remark: flag if produced solar power is estimated to be more than 500 watts
+                    type: bool
+                    eval: sh...() > 500
+                    eval_trigger: ..
+
+                g10:
+                    remark: flag if produced solar power is estimated to be more than 1000 watts
+                    type: bool
+                    eval: sh...() > 1000
+                    eval_trigger: ..
+
+                g15:
+                    remark: flag if produced solar power is estimated to be more than 1500 watts
+                    type: bool
+                    eval: sh...() > 1500
+                    eval_trigger: ..
+
+                g20:
+                    remark: flag if produced solar power is estimated to be more than 2000 watts
+                    type: bool
+                    eval: sh...() > 2000
+                    eval_trigger: ..
+
+                g25:
+                    remark: flag if produced solar power is estimated to be more than 2500 watts
+                    type: bool
+                    eval: sh...() > 2500
+                    eval_trigger: ..
+
+                g30:
+                    remark: flag if produced solar power is estimated to be more than 3000 watts
+                    type: bool
+                    eval: sh...() > 3000
+                    eval_trigger: ..
+
+                g35:
+                    remark: flag if produced solar power is estimated to be more than 3500 watts
+                    type: bool
+                    eval: sh...() > 3500
+                    eval_trigger: ..
+
+            h2:
+                remark: data for current hour + 2 (in reference to data_hour)
+                type: num
+                eval: sh....dict.get(sh....data_hour() + 2, 0)
+                eval_trigger: ...
+
+                g5:
+                    remark: flag if produced solar power is estimated to be more than 500 watts
+                    type: bool
+                    eval: sh...() > 500
+                    eval_trigger: ..
+
+                g10:
+                    remark: flag if produced solar power is estimated to be more than 1000 watts
+                    type: bool
+                    eval: sh...() > 1000
+                    eval_trigger: ..
+
+                g15:
+                    remark: flag if produced solar power is estimated to be more than 1500 watts
+                    type: bool
+                    eval: sh...() > 1500
+                    eval_trigger: ..
+
+                g20:
+                    remark: flag if produced solar power is estimated to be more than 2000 watts
+                    type: bool
+                    eval: sh...() > 2000
+                    eval_trigger: ..
+
+                g25:
+                    remark: flag if produced solar power is estimated to be more than 2500 watts
+                    type: bool
+                    eval: sh...() > 2500
+                    eval_trigger: ..
+
+                g30:
+                    remark: flag if produced solar power is estimated to be more than 3000 watts
+                    type: bool
+                    eval: sh...() > 3000
+                    eval_trigger: ..
+
+                g35:
+                    remark: flag if produced solar power is estimated to be more than 3500 watts
+                    type: bool
+                    eval: sh...() > 3500
+                    eval_trigger: ..
+
+            h3:
+                remark: data for current hour + 3 (in reference to data_hour)
+                type: num
+                eval: sh....dict.get(sh....data_hour() + 3, 0)
+                eval_trigger: ...
+
+                g5:
+                    remark: flag if produced solar power is estimated to be more than 500 watts
+                    type: bool
+                    eval: sh...() > 500
+                    eval_trigger: ..
+
+                g10:
+                    remark: flag if produced solar power is estimated to be more than 1000 watts
+                    type: bool
+                    eval: sh...() > 1000
+                    eval_trigger: ..
+
+                g15:
+                    remark: flag if produced solar power is estimated to be more than 1500 watts
+                    type: bool
+                    eval: sh...() > 1500
+                    eval_trigger: ..
+
+                g20:
+                    remark: flag if produced solar power is estimated to be more than 2000 watts
+                    type: bool
+                    eval: sh...() > 2000
+                    eval_trigger: ..
+
+                g25:
+                    remark: flag if produced solar power is estimated to be more than 2500 watts
+                    type: bool
+                    eval: sh...() > 2500
+                    eval_trigger: ..
+
+                g30:
+                    remark: flag if produced solar power is estimated to be more than 3000 watts
+                    type: bool
+                    eval: sh...() > 3000
+                    eval_trigger: ..
+
+                g35:
+                    remark: flag if produced solar power is estimated to be more than 3500 watts
+                    type: bool
+                    eval: sh...() > 3500
+                    eval_trigger: ..
+
+            h4:
+                remark: data for current hour + 4 (in reference to data_hour)
+                type: num
+                eval: sh....dict.get(sh....data_hour() + 4, 0)
+                eval_trigger: ...
+
+                g5:
+                    remark: flag if produced solar power is estimated to be more than 500 watts
+                    type: bool
+                    eval: sh...() > 500
+                    eval_trigger: ..
+
+                g10:
+                    remark: flag if produced solar power is estimated to be more than 1000 watts
+                    type: bool
+                    eval: sh...() > 1000
+                    eval_trigger: ..
+
+                g15:
+                    remark: flag if produced solar power is estimated to be more than 1500 watts
+                    type: bool
+                    eval: sh...() > 1500
+                    eval_trigger: ..
+
+                g20:
+                    remark: flag if produced solar power is estimated to be more than 2000 watts
+                    type: bool
+                    eval: sh...() > 2000
+                    eval_trigger: ..
+
+                g25:
+                    remark: flag if produced solar power is estimated to be more than 2500 watts
+                    type: bool
+                    eval: sh...() > 2500
+                    eval_trigger: ..
+
+                g30:
+                    remark: flag if produced solar power is estimated to be more than 3000 watts
+                    type: bool
+                    eval: sh...() > 3000
+                    eval_trigger: ..
+
+                g35:
+                    remark: flag if produced solar power is estimated to be more than 3500 watts
+                    type: bool
+                    eval: sh...() > 3500
+                    eval_trigger: ..
+
+            h5:
+                remark: data for current hour + 5 (in reference to data_hour)
+                type: num
+                eval: sh....dict.get(sh....data_hour() + 5, 0)
+                eval_trigger: ...
+
+                g5:
+                    remark: flag if produced solar power is estimated to be more than 500 watts
+                    type: bool
+                    eval: sh...() > 500
+                    eval_trigger: ..
+
+                g10:
+                    remark: flag if produced solar power is estimated to be more than 1000 watts
+                    type: bool
+                    eval: sh...() > 1000
+                    eval_trigger: ..
+
+                g15:
+                    remark: flag if produced solar power is estimated to be more than 1500 watts
+                    type: bool
+                    eval: sh...() > 1500
+                    eval_trigger: ..
+
+                g20:
+                    remark: flag if produced solar power is estimated to be more than 2000 watts
+                    type: bool
+                    eval: sh...() > 2000
+                    eval_trigger: ..
+
+                g25:
+                    remark: flag if produced solar power is estimated to be more than 2500 watts
+                    type: bool
+                    eval: sh...() > 2500
+                    eval_trigger: ..
+
+                g30:
+                    remark: flag if produced solar power is estimated to be more than 3000 watts
+                    type: bool
+                    eval: sh...() > 3000
+                    eval_trigger: ..
+
+                g35:
+                    remark: flag if produced solar power is estimated to be more than 3500 watts
+                    type: bool
+                    eval: sh...() > 3500
+                    eval_trigger: ..
+
+            h6:
+                remark: data for current hour + 6 (in reference to data_hour)
+                type: num
+                eval: sh....dict.get(sh....data_hour() + 6, 0)
+                eval_trigger: ...
+
+                g5:
+                    remark: flag if produced solar power is estimated to be more than 500 watts
+                    type: bool
+                    eval: sh...() > 500
+                    eval_trigger: ..
+
+                g10:
+                    remark: flag if produced solar power is estimated to be more than 1000 watts
+                    type: bool
+                    eval: sh...() > 1000
+                    eval_trigger: ..
+
+                g15:
+                    remark: flag if produced solar power is estimated to be more than 1500 watts
+                    type: bool
+                    eval: sh...() > 1500
+                    eval_trigger: ..
+
+                g20:
+                    remark: flag if produced solar power is estimated to be more than 2000 watts
+                    type: bool
+                    eval: sh...() > 2000
+                    eval_trigger: ..
+
+                g25:
+                    remark: flag if produced solar power is estimated to be more than 2500 watts
+                    type: bool
+                    eval: sh...() > 2500
+                    eval_trigger: ..
+
+                g30:
+                    remark: flag if produced solar power is estimated to be more than 3000 watts
+                    type: bool
+                    eval: sh...() > 3000
+                    eval_trigger: ..
+
+                g35:
+                    remark: flag if produced solar power is estimated to be more than 3500 watts
+                    type: bool
+                    eval: sh...() > 3500
+                    eval_trigger: ..
+
+        power500:
+            remark: flag if power is estimated to be more than 500 watts
+
+            h1:
+                remark: flag if power is estimed to be more than 500 watts for the next 1 hours (in reference to data_hour)
+                type: bool
+                eval: sh....hours.h0.g5() and sh....hours.h1.g5()
+                eval_trigger: ...
+
+            h2:
+                remark: flag if power is estimed to be more than 500 watts for the next 2 hours (in reference to data_hour)
+                type: bool
+                eval: sh....hours.h0.g5() and sh....hours.h1.g5() and sh....hours.h2.g5()
+                eval_trigger: ...
+
+            h3:
+                remark: flag if power is estimed to be more than 500 watts for the next 3 hours (in reference to data_hour)
+                type: bool
+                eval: sh....hours.h0.g5() and sh....hours.h1.g5() and sh....hours.h2.g5() and sh....hours.h3.g5()
+                eval_trigger: ...
+
+            h4:
+                remark: flag if power is estimed to be more than 500 watts for the next 4 hours (in reference to data_hour)
+                type: bool
+                eval: sh....hours.h0.g5() and sh....hours.h1.g5() and sh....hours.h2.g5() and sh....hours.h3.g5() and sh....hours.h4.g5()
+                eval_trigger: ...
+
+            h5:
+                remark: flag if power is estimed to be more than 500 watts for the next 5 hours (in reference to data_hour)
+                type: bool
+                eval: sh....hours.h0.g5() and sh....hours.h1.g5() and sh....hours.h2.g5() and sh....hours.h3.g5() and sh....hours.h4.g5() and sh....hours.h5.g5()
+                eval_trigger: ...
+
+        power1000:
+            remark: flag if power is estimated to be more than 1000 watts
+
+            h1:
+                remark: flag if power is estimed to be more than 1000 watts for the next 1 hours (in reference to data_hour)
+                type: bool
+                eval: sh....hours.h0.g10() and sh....hours.h1.g10()
+                eval_trigger: ...
+
+            h2:
+                remark: flag if power is estimed to be more than 1000 watts for the next 2 hours (in reference to data_hour)
+                type: bool
+                eval: sh....hours.h0.g10() and sh....hours.h1.g10() and sh....hours.h2.g10()
+                eval_trigger: ...
+
+            h3:
+                remark: flag if power is estimed to be more than 1000 watts for the next 3 hours (in reference to data_hour)
+                type: bool
+                eval: sh....hours.h0.g10() and sh....hours.h1.g10() and sh....hours.h2.g10() and sh....hours.h3.g10()
+                eval_trigger: ...
+
+            h4:
+                remark: flag if power is estimed to be more than 1000 watts for the next 4 hours (in reference to data_hour)
+                type: bool
+                eval: sh....hours.h0.g10() and sh....hours.h1.g10() and sh....hours.h2.g10() and sh....hours.h3.g10() and sh....hours.h4.g10()
+                eval_trigger: ...
+
+            h5:
+                remark: flag if power is estimed to be more than 1000 watts for the next 5 hours (in reference to data_hour)
+                type: bool
+                eval: sh....hours.h0.g10() and sh....hours.h1.g10() and sh....hours.h2.g10() and sh....hours.h3.g10() and sh....hours.h4.g10() and sh....hours.h5.g10()
+                eval_trigger: ...
+
+        power1500:
+            remark: flag if power is estimated to be more than 1500 watts
+
+            h1:
+                remark: flag if power is estimed to be more than 1500 watts for the next 1 hours (in reference to data_hour)
+                type: bool
+                eval: sh....hours.h0.g15() and sh....hours.h1.g15()
+                eval_trigger: ...
+
+            h2:
+                remark: flag if power is estimed to be more than 1500 watts for the next 2 hours (in reference to data_hour)
+                type: bool
+                eval: sh....hours.h0.g15() and sh....hours.h1.g15() and sh....hours.h2.g15()
+                eval_trigger: ...
+
+            h3:
+                remark: flag if power is estimed to be more than 1500 watts for the next 3 hours (in reference to data_hour)
+                type: bool
+                eval: sh....hours.h0.g15() and sh....hours.h1.g15() and sh....hours.h2.g15() and sh....hours.h3.g15()
+                eval_trigger: ...
+
+            h4:
+                remark: flag if power is estimed to be more than 1500 watts for the next 4 hours (in reference to data_hour)
+                type: bool
+                eval: sh....hours.h0.g15() and sh....hours.h1.g15() and sh....hours.h2.g15() and sh....hours.h3.g15() and sh....hours.h4.g15()
+                eval_trigger: ...
+
+            h5:
+                remark: flag if power is estimed to be more than 1500 watts for the next 5 hours (in reference to data_hour)
+                type: bool
+                eval: sh....hours.h0.g15() and sh....hours.h1.g15() and sh....hours.h2.g15() and sh....hours.h3.g15() and sh....hours.h4.g15() and sh....hours.h5.g15()
+                eval_trigger: ...
+
+        power2000:
+            remark: flag if power is estimated to be more than 2000 watts
+
+            h1:
+                remark: flag if power is estimed to be more than 2000 watts for the next 1 hours (in reference to data_hour)
+                type: bool
+                eval: sh....hours.h0.g20() and sh....hours.h1.g20()
+                eval_trigger: ...
+
+            h2:
+                remark: flag if power is estimed to be more than 2000 watts for the next 2 hours (in reference to data_hour)
+                type: bool
+                eval: sh....hours.h0.g20() and sh....hours.h1.g20() and sh....hours.h2.g20()
+                eval_trigger: ...
+
+            h3:
+                remark: flag if power is estimed to be more than 2000 watts for the next 3 hours (in reference to data_hour)
+                type: bool
+                eval: sh....hours.h0.g20() and sh....hours.h1.g20() and sh....hours.h2.g20() and sh....hours.h3.g20()
+                eval_trigger: ...
+
+            h4:
+                remark: flag if power is estimed to be more than 2000 watts for the next 4 hours (in reference to data_hour)
+                type: bool
+                eval: sh....hours.h0.g20() and sh....hours.h1.g20() and sh....hours.h2.g20() and sh....hours.h3.g20() and sh....hours.h4.g20()
+                eval_trigger: ...
+
+            h5:
+                remark: flag if power is estimed to be more than 2000 watts for the next 5 hours (in reference to data_hour)
+                type: bool
+                eval: sh....hours.h0.g20() and sh....hours.h1.g20() and sh....hours.h2.g20() and sh....hours.h3.g20() and sh....hours.h4.g20() and sh....hours.h5.g20()
+                eval_trigger: ...
+
+        power2500:
+            remark: flag if power is estimated to be more than 2500 watts
+
+            h1:
+                remark: flag if power is estimed to be more than 2500 watts for the next 1 hours (in reference to data_hour)
+                type: bool
+                eval: sh....hours.h0.g25() and sh....hours.h1.g25()
+                eval_trigger: ...
+
+            h2:
+                remark: flag if power is estimed to be more than 2500 watts for the next 2 hours (in reference to data_hour)
+                type: bool
+                eval: sh....hours.h0.g25() and sh....hours.h1.g25() and sh....hours.h2.g25()
+                eval_trigger: ...
+
+            h3:
+                remark: flag if power is estimed to be more than 2500 watts for the next 3 hours (in reference to data_hour)
+                type: bool
+                eval: sh....hours.h0.g25() and sh....hours.h1.g25() and sh....hours.h2.g25() and sh....hours.h3.g25()
+                eval_trigger: ...
+
+            h4:
+                remark: flag if power is estimed to be more than 2500 watts for the next 4 hours (in reference to data_hour)
+                type: bool
+                eval: sh....hours.h0.g25() and sh....hours.h1.g25() and sh....hours.h2.g25() and sh....hours.h3.g25() and sh....hours.h4.g25()
+                eval_trigger: ...
+
+            h5:
+                remark: flag if power is estimed to be more than 2500 watts for the next 5 hours (in reference to data_hour)
+                type: bool
+                eval: sh....hours.h0.g25() and sh....hours.h1.g25() and sh....hours.h2.g25() and sh....hours.h3.g25() and sh....hours.h4.g25() and sh....hours.h5.g25()
+                eval_trigger: ...
+
+        power3000:
+            remark: flag if power is estimated to be more than 3000 watts
+
+            h1:
+                remark: flag if power is estimed to be more than 3000 watts for the next 1 hours (in reference to data_hour)
+                type: bool
+                eval: sh....hours.h0.g30() and sh....hours.h1.g30()
+                eval_trigger: ...
+
+            h2:
+                remark: flag if power is estimed to be more than 3000 watts for the next 2 hours (in reference to data_hour)
+                type: bool
+                eval: sh....hours.h0.g30() and sh....hours.h1.g30() and sh....hours.h2.g30()
+                eval_trigger: ...
+
+            h3:
+                remark: flag if power is estimed to be more than 3000 watts for the next 3 hours (in reference to data_hour)
+                type: bool
+                eval: sh....hours.h0.g30() and sh....hours.h1.g30() and sh....hours.h2.g30() and sh....hours.h3.g30()
+                eval_trigger: ...
+
+            h4:
+                remark: flag if power is estimed to be more than 3000 watts for the next 4 hours (in reference to data_hour)
+                type: bool
+                eval: sh....hours.h0.g30() and sh....hours.h1.g30() and sh....hours.h2.g30() and sh....hours.h3.g30() and sh....hours.h4.g30()
+                eval_trigger: ...
+
+            h5:
+                remark: flag if power is estimed to be more than 3000 watts for the next 5 hours (in reference to data_hour)
+                type: bool
+                eval: sh....hours.h0.g30() and sh....hours.h1.g30() and sh....hours.h2.g30() and sh....hours.h3.g30() and sh....hours.h4.g30() and sh....hours.h5.g30()
+                eval_trigger: ...
+
+        power3500:
+            remark: flag if power is estimated to be more than 3500 watts
+
+            h1:
+                remark: flag if power is estimed to be more than 3500 watts for the next 1 hours (in reference to data_hour)
+                type: bool
+                eval: sh....hours.h0.g35() and sh....hours.h1.g35()
+                eval_trigger: ...
+
+            h2:
+                remark: flag if power is estimed to be more than 3500 watts for the next 2 hours (in reference to data_hour)
+                type: bool
+                eval: sh....hours.h0.g35() and sh....hours.h1.g35() and sh....hours.h2.g35()
+                eval_trigger: ...
+
+            h3:
+                remark: flag if power is estimed to be more than 3500 watts for the next 3 hours (in reference to data_hour)
+                type: bool
+                eval: sh....hours.h0.g35() and sh....hours.h1.g35() and sh....hours.h2.g35() and sh....hours.h3.g35()
+                eval_trigger: ...
+
+            h4:
+                remark: flag if power is estimed to be more than 3500 watts for the next 4 hours (in reference to data_hour)
+                type: bool
+                eval: sh....hours.h0.g35() and sh....hours.h1.g35() and sh....hours.h2.g35() and sh....hours.h3.g35() and sh....hours.h4.g35()
+                eval_trigger: ...
+
+            h5:
+                remark: flag if power is estimed to be more than 3500 watts for the next 5 hours (in reference to data_hour)
+                type: bool
+                eval: sh....hours.h0.g35() and sh....hours.h1.g35() and sh....hours.h2.g35() and sh....hours.h3.g35() and sh....hours.h4.g35() and sh....hours.h5.g35()
+                eval_trigger: ...
 
 
 logic_parameters: NONE
-    # Definition of logic parameters defined by this plugin (enter 'logic_parameters: NONE', if section should be empty)
-    #logic_parameters: NONE
-


### PR DESCRIPTION
power checks are provided as item struct and as a plugin function, see plugin.yaml