### PR TITLE
KNX Plugin: update type check due to xmltodict no longer returning OrderedDict

### DIFF
--- a/knx/knxproj.py
+++ b/knx/knxproj.py
@@ -265,7 +265,7 @@ def _parse_knxproject(filename, password=None):
         top = ga_dict.get('GroupRange',None)
         if top is None: return GAs
 
-        if isinstance(top, OrderedDict):
+        if not isinstance(top, list):
             # if there is only one child defined in xml, an ordered dict is
             # returned here instead of a list
             # so we need to convert it to a list
@@ -277,7 +277,7 @@ def _parse_knxproject(filename, password=None):
             middle_dict = middle.get('GroupRange',None)
             if middle_dict is None: continue
 
-            if isinstance( middle_dict, OrderedDict):
+            if not isinstance( middle_dict, list):
                 # same as above
                 middle_ga = [middle_dict]
             else:
@@ -288,7 +288,7 @@ def _parse_knxproject(filename, password=None):
 
                 if last_dict is None: continue
 
-                if isinstance( last_dict, OrderedDict):
+                if not isinstance( last_dict, list):
                     # same as above
                     last_ga = [last_dict]
                 else:
@@ -309,3 +309,4 @@ def _parse_knxproject(filename, password=None):
     except Exception as e: 
         print("Error {} occurred".format(e))
     return GAs
+

--- a/knx/knxproj.py
+++ b/knx/knxproj.py
@@ -26,7 +26,6 @@ import copy
 import logging
 
 from pathlib import Path
-from collections import OrderedDict
 import xmltodict
 
 logger = logging.getLogger("knxproject")
@@ -309,4 +308,5 @@ def _parse_knxproject(filename, password=None):
     except Exception as e: 
         print("Error {} occurred".format(e))
     return GAs
+
 


### PR DESCRIPTION
fix knx plugin: update type check due to xmltodict no longer returning OrderedDict

Previously, we checked if `middle_dict` was an instance of `OrderedDict`:
```
if isinstance(middle_dict, OrderedDict):
```
However, per [xmltodict issue #252](https://github.com/martinblech/xmltodict/issues/252), recent versions of xmltodict no longer return an OrderedDict but standard dicts.

To accommodate this change, update the condition to:
```
if not isinstance(middle_dict, list):
```
which correctly handles cases where a `x_dict` is a dict object and to a list. ;-)

This ensures compatibility with the updated xmltodict behavior and prevents potential bugs caused by the old type check.
