### PR TITLE
Update requirements.txt of modbus_tcp

### DIFF
--- a/modbus_tcp/requirements.txt
+++ b/modbus_tcp/requirements.txt
@@ -1,1 +1,1 @@
-pymodbus>=3.5.2;python_version>='3.8'
+pymodbus<3.10;python_version>='3.8'


### PR DESCRIPTION
The plugin currently requires a pymodbus version smaller than 3.10