### PR TITLE
Fix rrd times

### DIFF
--- a/rrd/__init__.py
+++ b/rrd/__init__.py
@@ -250,7 +250,7 @@ class RRD(SmartPlugin):
         reply['series'] = sorted(tuples)
         reply['params'] = {'update': True, 'item': item, 'func': func, 'start': str(iend), 'end': str(iend + istep), 'step': str(istep), 'sid': sid}
         reply['update'] = self.get_sh().now() + datetime.timedelta(seconds=istep)
-        self.logger.warning("Returning series for {} from {} to {} with {} values".format(sid, iend, iend+istep, len(tuples) ))
+        self.logger.warning("Returning series for {} from {} to {} with {} values".format(sid, istart, iend, len(tuples) ))
         return reply
 
     def _single(self, func, start='1d', end='now', item=None):

--- a/rrd/__init__.py
+++ b/rrd/__init__.py
@@ -251,7 +251,7 @@ class RRD(SmartPlugin):
         reply['series'] = sorted(tuples)
         reply['params'] = {'update': True, 'item': item, 'func': func, 'start': str(iend + istep), 'end': str(iend + 2 * istep), 'step': str(istep), 'sid': sid}
         reply['update'] = self.get_sh().now() + datetime.timedelta(seconds=istep)
-        self.logger.warning("Returning series for {} from {} to {} with {} values".format(sid, istart, iend, len(tuples) ))
+        self.logger.info("Returning series for {} from {} to {} with {} values".format(sid, istart, iend, len(tuples) ))
         return reply
 
     def _single(self, func, start='1d', end='now', item=None):

--- a/rrd/__init__.py
+++ b/rrd/__init__.py
@@ -247,8 +247,9 @@ class RRD(SmartPlugin):
         for i, v in enumerate(data):
             if v[0] is not None:
                 tuples.append((mstart + i * mstep, v[0]))
+                iend = int( ( mstart + i * mstep ) / 1000 )
         reply['series'] = sorted(tuples)
-        reply['params'] = {'update': True, 'item': item, 'func': func, 'start': str(iend), 'end': str(iend + istep), 'step': str(istep), 'sid': sid}
+        reply['params'] = {'update': True, 'item': item, 'func': func, 'start': str(iend + istep), 'end': str(iend + 2 * istep), 'step': str(istep), 'sid': sid}
         reply['update'] = self.get_sh().now() + datetime.timedelta(seconds=istep)
         self.logger.warning("Returning series for {} from {} to {} with {} values".format(sid, istart, iend, len(tuples) ))
         return reply


### PR DESCRIPTION
my rrd plots are never updated. after reload of the smartvisu page, they are displayed but never updated.

root cause: rrdtool fetch will return a nan value at last item. the next call will always request future data.

```
$ rrdtool fetch var/rrd/erdgeschoss.gaestebad.temp.rrd AVERAGE --start now-63h # executed at 23:28
[..]
1762813200: 2.0100000000e+01                       <= Mon Nov 10 23:20:00 2025
1762813500: 2.0100000000e+01                       <= Mon Nov 10 23:25:00 2025
1762813800: -nan                                   <= Mon Nov 10 23:30:00 2025
```
the response will send:
  start: 1762814100   (iend+istep = Mon Nov 10 23:35:00 2025)

at 23:33 the next update is triggered, but at this time there are no values in the range 23:35-23:40

```
here some logs from the original behaviour:

2025-11-10  22:49:06 WARNING  plugins.rrd         Returning series for erdgeschoss.gaestebad.temp|avg|63h|now|100 from 1762811400 to 1762811700 with 755 values
2025-11-10  22:54:24 WARNING  plugins.rrd         Returning series for erdgeschoss.gaestebad.temp|avg|63h|now|100 from 1762812000 to 1762812300 with 0 values

2025-11-10  22:58:30 WARNING  plugins.rrd         Returning series for erdgeschoss.gaestebad.temp|avg|63h|now|100 from 1762812000 to 1762812300 with 755 values
2025-11-10  23:03:45 WARNING  plugins.rrd         Returning series for erdgeschoss.gaestebad.temp|avg|63h|now|100 from 1762812600 to 1762812900 with 0 values
2025-11-10  23:08:45 WARNING  plugins.rrd         Returning series for erdgeschoss.gaestebad.temp|avg|63h|now|100 from 1762813200 to 1762813500 with 0 values
```

this PR fixed the issue for me.