### PR TITLE
avm, sonos, yamaha: update lxml parser due to CVE-2026-41066

### DIFF
--- a/avm/__init__.py
+++ b/avm/__init__.py
@@ -4571,4 +4571,6 @@ def request_response_to_xml(request):
     """
     Parse request response to element object
     """
-    return ET.fromstring(request.content)
+    # added parser with resolve_entities option in response to CVE-2026-41066
+    xmlparser = ET.XMLParser(resolve_entities='internal')
+    return ET.fromstring(request.content, parser=xmlparser)

--- a/avm/tr064/action.py
+++ b/avm/tr064/action.py
@@ -37,6 +37,9 @@ class Action:
         self.namespaces = IGD_SERVICE_NAMESPACE if 'igd' in description_file else TR064_SERVICE_NAMESPACE
         self.control_namespace = IGD_CONTROL_NAMESPACE if 'igd' in description_file else TR064_CONTROL_NAMESPACE
 
+        # added parser with resolve_entities option in response to CVE-2026-41066
+        self._xmlparser = ET.XMLParser(resolve_entities='internal')
+
         ET.register_namespace('s', 'http://schemas.xmlsoap.org/soap/envelope/')
         ET.register_namespace('h', 'http://soap-authentication.org/digest/2001/10/')
 
@@ -92,7 +95,8 @@ class Action:
                                 verify=self.verify)
         if request.status_code != 200:
             try:
-                xml = ET.parse(BytesIO(request.content))
+                # added parser option in response to CVE-2026-41066
+                xml = ET.parse(BytesIO(request.content), parser=self._xmlparser)
             except Exception:
                 return request.status_code
             try:
@@ -104,7 +108,8 @@ class Action:
             return error_code if error_code is not None else request.status_code
 
         # Translate response and prepare dict
-        xml = ET.parse(BytesIO(request.content))
+        # added parser option in response to CVE-2026-41066
+        xml = ET.parse(BytesIO(request.content), parser=self._xmlparser)
         response = AttributeDict()
         for arg in list(xml.find('.//{{{}}}{}Response'.format(self.service_type, self.name))):
             name = self.out_arguments[arg.tag]

--- a/avm/tr064/client.py
+++ b/avm/tr064/client.py
@@ -44,7 +44,9 @@ class Client:
         # request = requests.get(f'{self.base_url}/{description_file}', verify=self.verify)
 
         if request.status_code == 200:
-            xml = ET.parse(BytesIO(request.content))
+            # added parser with resolve_entities option in response to CVE-2026-41066
+            xmlparser = ET.XMLParser(resolve_entities='internal')
+            xml = ET.parse(BytesIO(request.content), parser=xmlparser)
 
             for device in xml.findall('.//device', namespaces=self.namespaces):
                 name = device.findtext('deviceType', namespaces=self.namespaces).split(':')[-2]

--- a/avm/tr064/service.py
+++ b/avm/tr064/service.py
@@ -27,6 +27,9 @@ class Service:
         self.description_file = description_file
         self.namespaces = IGD_SERVICE_NAMESPACE if 'igd' in description_file else TR064_SERVICE_NAMESPACE
 
+        # added parser with resolve_entities option in response to CVE-2026-41066
+        self._xmlparser = ET.XMLParser(resolve_entities='internal')
+
     def __getattr__(self, name):
         if name not in self.actions:
             self._fetch_actions(self.scpdurl)
@@ -40,7 +43,8 @@ class Service:
         """Fetch action description."""
         request = requests.get('{0}{1}'.format(self.base_url, scpdurl), verify=self.verify)
         if request.status_code == 200:
-            xml = ET.parse(BytesIO(request.content))
+            # added parser option in response to CVE-2026-41066
+            xml = ET.parse(BytesIO(request.content), parser=self._xmlparser)
 
             for action in xml.findall('./actionList/action', namespaces=self.namespaces):
                 name = action.findtext('name', namespaces=self.namespaces)

--- a/sonos/soco/data_structures_entry.py
+++ b/sonos/soco/data_structures_entry.py
@@ -29,7 +29,8 @@ def from_didl_string(string):
         list: A list of one or more instances of `DidlObject` or a subclass
     """
     items = []
-    parser = ET.XMLParser(recover=True, encoding="utf-8")
+    # added resolve_entities in response to CVE-2026-41066 
+    parser = ET.XMLParser(recover=True, encoding="utf-8", resolve_entities='internal')
     root = ET.fromstring(string.encode("utf-8"), parser=parser)
     for elt in root:
         if elt.tag.endswith("item") or elt.tag.endswith("container"):

--- a/sonos/soco/zonegroupstate.py
+++ b/sonos/soco/zonegroupstate.py
@@ -395,6 +395,7 @@ class ZoneGroupState:
 
 def normalize_zgs_xml(xml):
     """Normalize the ZoneGroupState payload and return an lxml ElementTree instance."""
-    parser = LXML.XMLParser(remove_blank_text=True)  # pylint:disable=I1101
+    # added resolve_entities in response to CVE-2026-41066 
+    parser = LXML.XMLParser(remove_blank_text=True, resolve_entities='internal')  # pylint:disable=I1101
     tree = LXML.fromstring(xml, parser)  # pylint:disable=I1101
     return ZGS_TRANSFORM(tree)

--- a/yamaha/__init__.py
+++ b/yamaha/__init__.py
@@ -75,6 +75,9 @@ class Yamaha(SmartPlugin):
         self.mcast_buffer = 1024
         self.mcast_service = "urn:schemas-yamaha-com:service:X_YamahaRemoteControl:1"
 
+        # added parser with resolve_entities option in response to CVE-2026-41066
+        self._xmlparser = etree.XMLParser(resolve_entities='internal')
+
         # On initialization error use:
         if not REQUIRED_PACKAGE_IMPORTED:
             self._init_complete = False
@@ -194,7 +197,8 @@ class Yamaha(SmartPlugin):
             notice.text = 'On'
         else:
             notice.text = 'Off'
-        tree = etree.ElementTree(root)
+        # added parser option in response to CVE-2026-41066
+        tree = etree.ElementTree(root, parser=self._xmlparser)
         return self._return_document(tree)
 
     def _power(self, value, cmd='PUT'):
@@ -209,7 +213,8 @@ class Yamaha(SmartPlugin):
             power.text = 'Standby'
         elif value == 'GetParam':
             power.text = value
-        tree = etree.ElementTree(root)
+        # added parser option in response to CVE-2026-41066
+        tree = etree.ElementTree(root, parser=self._xmlparser)
         return self._return_document(tree)
 
     def _input(self, value, cmd='PUT'):
@@ -219,7 +224,8 @@ class Yamaha(SmartPlugin):
         input = etree.SubElement(system, 'Input')
         input_sel = etree.SubElement(input, 'Input_Sel')
         input_sel.text = value
-        tree = etree.ElementTree(root)
+        # added parser option in response to CVE-2026-41066
+        tree = etree.ElementTree(root, parser=self._xmlparser)
         return self._return_document(tree)
 
     def _volume(self, value, cmd='PUT'):
@@ -237,7 +243,8 @@ class Yamaha(SmartPlugin):
             exponent.text = '1'
             unit = etree.SubElement(level, 'Unit')
             unit.text = 'dB'
-        tree = etree.ElementTree(root)
+        # added parser option in response to CVE-2026-41066
+        tree = etree.ElementTree(root, parser=self._xmlparser)
         return self._return_document(tree)
 
     def _mute(self, value, cmd='PUT'):
@@ -252,7 +259,8 @@ class Yamaha(SmartPlugin):
             mute.text = 'Off'
         elif value == 'GetParam':
             mute.text = value
-        tree = etree.ElementTree(root)
+        # added parser option in response to CVE-2026-41066
+        tree = etree.ElementTree(root, parser=self._xmlparser)
         return self._return_document(tree)
 
     def _validate_inputs(self):
@@ -261,7 +269,8 @@ class Yamaha(SmartPlugin):
         system = etree.SubElement(root, 'System')
         state = etree.SubElement(system, 'Config')
         state.text = 'GetParam'
-        tree = etree.ElementTree(root)
+        # added parser option in response to CVE-2026-41066
+        tree = etree.ElementTree(root, parser=self._xmlparser)
         return self._return_document(tree)
 
     def _get_state(self):
@@ -270,7 +279,8 @@ class Yamaha(SmartPlugin):
         system = etree.SubElement(root, 'Main_Zone')
         state = etree.SubElement(system, 'Basic_Status')
         state.text = 'GetParam'
-        tree = etree.ElementTree(root)
+        # added parser option in response to CVE-2026-41066
+        tree = etree.ElementTree(root, parser=self._xmlparser)
         return self._return_document(tree)
 
     def _get_value(self, notify_cmd, yamaha_host):
@@ -292,7 +302,8 @@ class Yamaha(SmartPlugin):
 
     def _return_value(self, state, cmd):
         try:
-            tree = etree.parse(StringIO(state))
+            # added parser option in response to CVE-2026-41066
+            tree = etree.parse(StringIO(state), parser=self._xmlparser)
         except Exception:
             return "Invalid data received"
         if cmd == 'input':


### PR DESCRIPTION
ref: https://github.com/advisories/GHSA-vfmq-68hx-4jfw/dependabot?query=user%3AsmarthomeNG

Added (new) default parser with resolve_entities='internal' set, otherwise unchanged.

Cannot test plugins, maintainers please check if they run properly.