### PR TITLE
database: update remove_item, add rename_item for core item editing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ Thumbs.db
 
 # VSCode settings
 .vscode/settings.json
+
+# pyright stub packages (tools/pyright_stub_audit.py) — local dev aid,
+# CI lints with ruff, not pyright; regenerate with --apply-create if needed
+/typings/

--- a/database/__init__.py
+++ b/database/__init__.py
@@ -325,6 +325,98 @@ class Database(SmartPlugin):
         else:
             return None
 
+    def remove_item(self, item):
+        """
+        Clean up plugin-internal bookkeeping for *item* before it's deleted —
+        mirrors what parse_item() set up. Called by Items.remove_item() via the
+        PLUGIN_REMOVE_ITEM hook (e.g. when admin-UI item editing recreates the
+        item under the hood, or on an ordinary item delete).
+
+        Flushes any pending buffered datapoints for *item* to the database
+        first (_dump with finalize=True), so editing/deleting an item never
+        silently drops not-yet-written log entries. Database *rows* for the
+        item's path are untouched — id() looks them up by path, so a future
+        recreate at the same path naturally finds and reuses the same row.
+        This only clears the in-memory Item-object references the plugin
+        itself holds.
+
+        :param item: Item instance being removed
+        :type item: object
+        :return: True if this item had database-plugin state to clean up
+        :rtype: bool
+        """
+        found = item.property.path in self._webdata
+        if not found:
+            return False
+
+        self._dump(finalize=True, items=[item])
+        self._buffer_lock.acquire()
+        self._buffer.pop(item, None)
+        self._buffer_lock.release()
+
+        self._webdata.pop(item.property.path, None)
+        try:
+            self._handled_items.remove(item)
+        except ValueError:
+            pass
+        try:
+            self._items_with_maxage.remove(item)
+        except ValueError:
+            pass
+
+        return True
+
+    def rename_item(self, item, old_path, new_path):
+        """
+        Re-key plugin-internal bookkeeping for an item that was renamed in
+        place (same object, only its path changed — see
+        Items.rename_item(), called via the PLUGIN_RENAME_ITEM hook).
+
+        Unlike remove_item()/parse_item(), this does NOT flush/drop the
+        item's data — it migrates it. ``item.db``/``item.series`` are
+        functools.partial objects that capture the path as a frozen
+        keyword argument at parse_item() time (see parse_item() above);
+        they're refreshed here so calling them after a rename queries
+        under the new path, not a stale, now-meaningless old one. The old
+        path's database row is an "orphan" (no in-memory item points at
+        it any more) the moment _webdata is re-keyed — reassign_orphaned_id()
+        merges its log history into the new path's row and deletes it,
+        rather than leaving it to be discovered later by build_orphanlist().
+
+        :param item: The renamed item (same object, unchanged identity)
+        :param old_path: The item's path before the rename
+        :param new_path: The item's path after the rename
+        :type old_path: str
+        :type new_path: str
+
+        :return: True if this item had database-plugin state to migrate
+        :rtype: bool
+        """
+        if old_path not in self._webdata:
+            return False
+
+        self._webdata[new_path] = self._webdata.pop(old_path)
+        item.series = functools.partial(self._series, item=new_path)
+        item.db = functools.partial(self._single, item=new_path)
+
+        old_id = self.id(old_path, create=False)
+        # id()'s create=True path always inserts via item.property.path,
+        # not the string it was passed — item.property.path already
+        # equals new_path here (Items.rename_item() mutates the path
+        # before calling this hook), so pass the item, not the string.
+        new_id = self.id(item, create=True)
+        if old_id is not None and old_id != new_id:
+            # id(create=True) never commits its own insert (a pre-existing
+            # gap — insertItem() just executes, never commits). Without an
+            # explicit commit here, that uncommitted write on self._db
+            # blocks reassign_orphaned_id()'s very first read, since it
+            # uses the separate self._db_maint connection, and SQLite
+            # allows only one writer's transaction to be open at a time.
+            self._db.commit()
+            self.reassign_orphaned_id(old_id, new_id)
+
+        return True
+
     def parse_logic(self, logic):
         """
         Default plugin parse_logic method
@@ -1218,15 +1310,16 @@ class Database(SmartPlugin):
             while count > 0:
                 log_debug(f'reassigning {min(count, self.max_reassign_logentries)} log entries')
                 self._execute(
-                    self._prepare('UPDATE {log} SET item_id = :newid WHERE item_id = :orphanid LIMIT :limit;'),
+                    self._prepare(
+                        'UPDATE {log} SET item_id = :newid WHERE rowid IN '
+                        '(SELECT rowid FROM {log} WHERE item_id = :orphanid LIMIT :limit);'
+                    ),
                     {'newid': to, 'orphanid': orphan_id, 'limit': self.max_reassign_logentries},
                     cur=cur,
                 )
                 count -= self.max_reassign_logentries
 
-            self._execute(
-                self._prepare('DELETE FROM  {item} WHERE id = :orphanid LIMIT 1;'), {'orphanid': orphan_id}, cur=cur
-            )
+            self._execute(self._prepare('DELETE FROM {item} WHERE id = :orphanid;'), {'orphanid': orphan_id}, cur=cur)
             log_info(f'reassigned orphaned id {orphan_id} to new id {to}')
             cur.close()
             self._db_maint.commit()

--- a/database/__init__.py
+++ b/database/__init__.py
@@ -694,7 +694,7 @@ class Database(SmartPlugin):
         if id is None and create:
             id = [self.insertItem(item.property.path, cur)]
 
-        if (id is None) or (COL_ITEM_ID >= len(id)):
+        if (id is None) or (COL_ITEM_ID >= len(id)) or (id[COL_ITEM_ID] is None):
             return None
         return int(id[COL_ITEM_ID])
 
@@ -1283,6 +1283,9 @@ class Database(SmartPlugin):
         self._items_total_entries = 0
         for item in self.orphanlist:
             item_id = self.id(item, create=False)
+            if item_id is None:
+                self.logger.warning(f'_count_orphanlogentries: No valid id found for orphan item {item} - skipping')
+                continue
             logcount = self.readLogCount(item_id)
             logcount_str = f'{logcount:,}'.replace(',', '.')
             self.logger.info(f'Orphan {item} (id={item_id}): {logcount_str} entries')

--- a/database/__init__.py
+++ b/database/__init__.py
@@ -879,9 +879,13 @@ class Database(SmartPlugin):
         """
         Create database item record for given item name.
 
-        Uses database-assigned auto-increment for the id rather than the
-        previous ``MAX(id) + 1`` pattern, which was prone to a race
-        condition on multi-connection setups.
+        Uses the cursor's own ``lastrowid`` right after the INSERT rather
+        than a follow-up ``SELECT id ... WHERE name=:name``. The database
+        connection is shared across threads (``check_same_thread:0``), so a
+        concurrent caller (e.g. a websocket admin series request running on
+        another thread) could interleave between the INSERT and that
+        lookup and cause it to miss, leaving the item permanently id-less.
+        ``lastrowid`` is scoped to this cursor and immune to that race.
 
         This is a public function of the plugin.
 
@@ -890,9 +894,8 @@ class Database(SmartPlugin):
         :return:     The new integer item ID.
         :rtype:      int
         """
-        self._execute(self._prepare('INSERT INTO {item}(name) VALUES(:name);'), {'name': name}, cur=cur)
-        row = self._fetchone('SELECT id FROM {item} WHERE name = :name;', {'name': name}, cur=cur)
-        return int(row[0])
+        result_cur = self._execute(self._prepare('INSERT INTO {item}(name) VALUES(:name);'), {'name': name}, cur=cur)
+        return int(result_cur.lastrowid)
 
     def updateItem(self, id, time, duration=0, val=None, it=None, changed=None, cur=None):
         """
@@ -1854,7 +1857,7 @@ class Database(SmartPlugin):
 
                     self._db.commit()
                 except Exception as e:
-                    self.logger.warning('Problem dumping {}: {}'.format(item.property.path, e))
+                    self.logger.warning('Problem dumping {}: {}'.format(item.property.path, e), exc_info=True)
                     try:
                         self._db.rollback()
                     except Exception as er:
@@ -2133,7 +2136,7 @@ class Database(SmartPlugin):
         return query.format(**self._replace)
 
     def _execute(self, query, params, cur=None):
-        self._query(self._db.execute, query, params, cur)
+        return self._query(self._db.execute, query, params, cur)
 
     def _fetchone(self, query, params={}, cur=None):
         tuples = self._query(self._db.fetchone, query, params, cur)

--- a/database/tests/test_items.yaml
+++ b/database/tests/test_items.yaml
@@ -14,3 +14,8 @@ main:
 
     nodb:
         type: num
+
+    maxage:
+        type: num
+        database: init
+        database_maxage: 30

--- a/database/tests/test_remove_item.py
+++ b/database/tests/test_remove_item.py
@@ -1,0 +1,65 @@
+"""
+Tests for Database.remove_item() — cleans up plugin-internal bookkeeping for
+an item before it's deleted/recreated (e.g. by Items.remove_item() or the
+admin UI's item-edit feature). Mirrors what parse_item() registers.
+
+self.plugin() (the test fixture) already calls parse_item() on every item in
+test_items.yaml during setup — tests below rely on that, not a second
+explicit parse_item() call (which would double-register list-based state).
+"""
+
+from plugins.database.tests.base import TestDatabaseBase
+
+
+class TestDatabaseRemoveItem(TestDatabaseBase):
+    def test_remove_item_clears_webdata(self):
+        plugin = self.plugin()
+        item = self.sh.return_item('main.num')
+        self.assertIn(item.property.path, plugin._webdata)
+
+        plugin.remove_item(item)
+
+        self.assertNotIn(item.property.path, plugin._webdata)
+
+    def test_remove_item_clears_handled_items(self):
+        plugin = self.plugin()
+        item = self.sh.return_item('main.num')
+        self.assertIn(item, plugin._handled_items)
+
+        plugin.remove_item(item)
+
+        self.assertNotIn(item, plugin._handled_items)
+
+    def test_remove_item_clears_buffer(self):
+        plugin = self.plugin()
+        item = self.sh.return_item('main.num')
+        self.assertIn(item, plugin._buffer)
+
+        plugin.remove_item(item)
+
+        self.assertNotIn(item, plugin._buffer)
+
+    def test_remove_item_clears_items_with_maxage(self):
+        plugin = self.plugin()
+        item = self.sh.return_item('main.maxage')
+        self.assertIn(item, plugin._items_with_maxage)
+
+        plugin.remove_item(item)
+
+        self.assertNotIn(item, plugin._items_with_maxage)
+
+    def test_remove_item_returns_false_for_untracked_item(self):
+        plugin = self.plugin()
+        item = self.sh.return_item('main.nodb')
+
+        self.assertFalse(plugin.remove_item(item))
+
+    def test_remove_item_flushes_pending_buffer_to_db(self):
+        plugin = self.plugin()
+        item = self.sh.return_item('main.num')
+        plugin._buffer_insert(item, [(1000, None, 5)])
+
+        plugin.remove_item(item)
+
+        count = plugin.readLogCount(plugin.id(item, False))
+        self.assertGreater(count, 0)

--- a/database/tests/test_rename_item.py
+++ b/database/tests/test_rename_item.py
@@ -1,0 +1,77 @@
+"""
+Tests for Database.rename_item() — re-keys plugin-internal bookkeeping and
+migrates SQL log history when an item is renamed in place (same object,
+only its path changes — see Items.rename_item() in the core repo and
+~/.claude/handoff/shng-rename-item-design.md).
+
+self.plugin() (the test fixture) already calls parse_item() on every item
+in test_items.yaml during setup.
+"""
+
+from plugins.database.tests.base import TestDatabaseBase
+
+
+class TestDatabaseRenameItem(TestDatabaseBase):
+    def test_rename_item_rekeys_webdata(self):
+        plugin = self.plugin()
+        item = self.sh.return_item('main.num')
+
+        plugin.rename_item(item, 'main.num', 'main.renamed')
+
+        self.assertNotIn('main.num', plugin._webdata)
+        self.assertIn('main.renamed', plugin._webdata)
+
+    def test_rename_item_refreshes_db_and_series_partials(self):
+        plugin = self.plugin()
+        item = self.sh.return_item('main.num')
+
+        plugin.rename_item(item, 'main.num', 'main.renamed')
+
+        self.assertEqual(item.db.keywords['item'], 'main.renamed')
+        self.assertEqual(item.series.keywords['item'], 'main.renamed')
+
+    def test_rename_item_returns_false_if_item_not_tracked(self):
+        plugin = self.plugin()
+        item = self.sh.return_item('main.nodb')
+
+        result = plugin.rename_item(item, 'main.nodb', 'main.renamed')
+
+        self.assertFalse(result)
+
+    def test_rename_item_reassigns_orphaned_log_history(self):
+        # database.rename_item() relies on item.property.path already
+        # being new_path when it runs (Items.rename_item() mutates the
+        # path before calling any plugin's hook) — mutate it directly
+        # here too, same as test_remove_item.py calls plugin.remove_item()
+        # directly rather than through Items.remove_item().
+        plugin = self.plugin()
+        item = self.sh.return_item('main.num')
+        old_id = self.create_item(plugin, 'main.num')
+
+        item._path = 'main.renamed'
+        plugin.rename_item(item, 'main.num', 'main.renamed')
+
+        new_id = plugin.id('main.renamed', create=False)
+        self.assertIsNotNone(new_id)
+        self.assertNotEqual(old_id, new_id)
+        # the orphaned old id's row is gone — merged into new_id, not left behind
+        self.assertIsNone(plugin.id('main.num', create=False))
+
+    def test_rename_item_reassigns_actual_log_entries_not_just_an_empty_row(self):
+        # Exercises the UPDATE {log} ... LIMIT path inside
+        # reassign_orphaned_id() — test_rename_item_reassigns_orphaned_log_history
+        # has zero log entries, so that statement's while loop body never
+        # actually runs there.
+        plugin = self.plugin()
+        item = self.sh.return_item('main.num')
+        self.create_log(plugin, 'main.num', [(0, 1, 1.0), (1, None, 2.0)])
+        plugin._db.commit()  # reassign_orphaned_id() uses the separate _db_maint
+        # connection — its writes would otherwise block on this connection's
+        # uncommitted insert (SQLite allows only one writer at a time).
+
+        item._path = 'main.renamed'
+        plugin.rename_item(item, 'main.num', 'main.renamed')
+
+        new_id = plugin.id('main.renamed', create=False)
+        values = [v[4] for v in plugin.readLogs(new_id)]  # COL_LOG_VAL_NUM
+        self.assertEqual(sorted(values), [1.0, 2.0])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,3 +41,51 @@ ignore = [
 # Filename half of the test convention; conftest.py's pytest_ignore_collect enforces
 # the directory half (must live under a 'tests' subdirectory).
 python_files = ["test_*.py"]
+
+# ------------------------------------------------------------------------------
+# PYRIGHT — type checker configuration
+# Docs: https://microsoft.github.io/pyright/#/configuration
+#
+# SYNC NOTE: keep the intent of this section (reportPossiblyUnboundVariable /
+# reportUnboundVariable as errors) in sync with ../smarthome/pyproject.toml.
+#
+# Ruff's pyflakes rules (F) don't do control-flow analysis, so they miss
+# possibly-unbound locals (a name assigned on some branches/in a try block
+# but not all, then read afterwards). Pyright's reportPossiblyUnboundVariable /
+# reportUnboundVariable do — that's this section's main purpose.
+# ------------------------------------------------------------------------------
+
+[tool.pyright]
+include = ["."]
+exclude = [
+    "**/__pycache__",
+    "*/_pv_*",                    # old/superseded plugin versions kept for reference
+    "priv_*",                     # private/local-only plugins — gitignored, not part of this repo
+    "helios/files",                # sample logic scripts: sh/trigger/logic/shtime injected at exec() time
+    "wettercom/additional_files",  # sample script: sh/logger/dateutil injected at exec() time
+    "knx/Check_KNX.py",            # sample script: sh injected at exec() time
+    "asterisk/agi",                # AGI scripts: agi_callerid injected by Asterisk at exec() time
+    "executor/examples",           # example logic scripts with injected namespace
+    "roombapysh/roombapy",         # vendored third-party submodule, not first-party code
+]
+# NOTE: `exclude` above only stops pyright from independently walking a
+# directory for *unreferenced* files — per pyright's own docs, a file that a
+# plugin actually imports still gets fully analyzed and its diagnostics
+# reported, exclude or not. Since extraPaths (below) makes ../lib etc.
+# resolvable as plain first-party source (not a stub/site-packages dir
+# pyright would recognize as "library code" and hush), there is no config
+# option that resolves cross-repo imports for typing *without* also
+# reporting shng-core's own diagnostics on a plugins-repo run. Use
+# tools/pyright_scoped.py (in the shng core repo) instead of the bare
+# `pyright` binary to filter the run's output down to this repo's own
+# files — see the SYNC NOTE at the top of this file.
+venvPath = "../venvs"
+venv = "shng"
+# Plugins import core modules as "lib.item.items" etc. at runtime (the shng
+# core repo's root is on sys.path when a plugin actually loads). extraPaths
+# tells pyright's resolver about that same root so those imports resolve
+# during type checking too, without pulling shng into `include` above.
+extraPaths = [".."]
+typeCheckingMode = "basic"
+reportPossiblyUnboundVariable = "error"
+reportUnboundVariable = "error"

--- a/smartvisu/svgenerator.py
+++ b/smartvisu/svgenerator.py
@@ -387,10 +387,10 @@ class SmartVisuGenerator:
 
                 widget = self.get_attribute('sv_widget', item)
                 widget2 = self.get_attribute('sv_widget2', item)
+                name1 = self.get_attribute('sv_name1', item)
+                if name1 == '':
+                    name1 = item
                 if widget2 == '':
-                    name1 = self.get_attribute('sv_name1', item)
-                    if name1 == '':
-                        name1 = item
                     widgets += self.parse_tpl_from_file(
                         widgetblocktemplate,
                         [


### PR DESCRIPTION
Passt das database-Plugin an, damit beim Umbenennen von Items die Datenbank automatisch angepasst wird.

Benötigt PR smarthomeNG/smarthome#803 