### PR TITLE
database: enable reversible invalidation of values (instead of deleting)

### DIFF
--- a/database/__init__.py
+++ b/database/__init__.py
@@ -58,6 +58,7 @@ from .constants import (
     COL_LOG_VAL_NUM,
     COL_LOG_VAL_STR,
     BufferEntry,
+    QUALITY_INVALID,
     QUALITY_NO_DATA,
     QUALITY_VALID,
 )
@@ -1218,6 +1219,38 @@ class Database(SmartPlugin):
             self.logger.error('Exception in function deleteLog during readLogCount: {}'.format(e))
 
         return
+
+    def markLogInvalid(self, id, time=None, changed=None, cur=None, with_commit=True):
+        """
+        Reversibly flag a database log record as invalid, preserving its value
+
+        This is a public function of the plugin. Unlike deleteLog(), the row is
+        kept - only its val_quality is set to QUALITY_INVALID, which excludes it
+        from time-weighted aggregations (avg, sum, integrate, on, min, max) while
+        leaving val_str/val_num/val_bool/duration untouched so the flag can be
+        undone with markLogValid().
+
+        :param id: Database ID of item to flag the record for
+        :param time: Restrict flagging to given time (optional)
+        :param changed: Restrict flagging to given change time (optional)
+        :param cur: A database cursor object if available (optional)
+        :return:
+        """
+        self._log_store.set_quality(id, QUALITY_INVALID, time=time, changed=changed, cur=cur, commit=with_commit)
+
+    def markLogValid(self, id, time=None, changed=None, cur=None, with_commit=True):
+        """
+        Undo markLogInvalid(): restore a database log record's val_quality to valid
+
+        This is a public function of the plugin.
+
+        :param id: Database ID of item to restore the record for
+        :param time: Restrict restoring to given time (optional)
+        :param changed: Restrict restoring to given change time (optional)
+        :param cur: A database cursor object if available (optional)
+        :return:
+        """
+        self._log_store.set_quality(id, QUALITY_VALID, time=time, changed=changed, cur=cur, commit=with_commit)
 
     def build_orphanlist(self, log_activity=False):
         """

--- a/database/constants.py
+++ b/database/constants.py
@@ -47,6 +47,7 @@ COL_LOG_VAL_STR = 3
 COL_LOG_VAL_NUM = 4
 COL_LOG_VAL_BOOL = 5
 COL_LOG_CHANGED = 6
+COL_LOG_VAL_QUALITY = 7  # appended after COL_LOG at query-build time, not part of the tuple itself
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Data-quality flags  (stored in the val_quality column added in schema v7)
@@ -59,6 +60,14 @@ QUALITY_NO_DATA = 1
 All val_* columns are NULL for such entries.
 These rows are excluded from time-weighted aggregations (avg, sum, integrate,
 on, min, max) and appear as gaps in raw/visualisation queries."""
+
+QUALITY_INVALID = 2
+"""Value was known but has been manually flagged bad (e.g. via the webif's
+reversible "invalidate" action, replacing what used to be a hard delete).
+Unlike QUALITY_NO_DATA, val_* columns are preserved so the flag can be
+undone. Excluded from time-weighted aggregations exactly like
+QUALITY_NO_DATA - the exclusion filter treats any non-zero val_quality
+the same way."""
 
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/database/store.py
+++ b/database/store.py
@@ -319,6 +319,56 @@ class LogStore:
             self.logger.error('LogStore.delete_range: {}'.format(e))
             self._db.rollback()
 
+    def set_quality(
+        self,
+        item_id: int,
+        quality: int,
+        *,
+        time=None,
+        time_start=None,
+        time_end=None,
+        changed=None,
+        changed_start=None,
+        changed_end=None,
+        cur=None,
+        commit=True,
+    ) -> None:
+        """Set ``val_quality`` on matching log rows without touching their values.
+
+        Used for reversible invalidate/restore (e.g. the webif's "delete"
+        action), as opposed to :meth:`delete_range` which permanently
+        removes rows. ``duration``/``val_str``/``val_num``/``val_bool`` are
+        left untouched.
+
+        :param item_id:       Database item ID.
+        :param quality:       New ``val_quality`` value.
+        :param time:          Exact timestamp to match (optional).
+        :param time_start:    Lower bound on ``time`` (exclusive, optional).
+        :param time_end:      Upper bound on ``time`` (exclusive, optional).
+        :param changed:       Exact ``changed`` match (optional).
+        :param changed_start: Lower bound on ``changed`` (optional).
+        :param changed_end:   Upper bound on ``changed`` (optional).
+        :param cur:           Optional cursor.
+        :param commit:        If ``True`` (default) commit after the update.
+        """
+        where, params = build_where_clause(
+            item_id,
+            time=time,
+            time_start=time_start,
+            time_end=time_end,
+            changed=changed,
+            changed_start=changed_start,
+            changed_end=changed_end,
+        )
+        params['quality'] = quality
+        try:
+            self._execute('UPDATE {log} SET val_quality=:quality WHERE ' + where + ';', params, cur=cur)
+            if commit:
+                self._db.commit()
+        except Exception as e:
+            self.logger.error('LogStore.set_quality: {}'.format(e))
+            self._db.rollback()
+
     # ── read ─────────────────────────────────────────────────────────────────
 
     def find(self, item_id: int, time: int, cur=None) -> list:

--- a/database/tests/test_basic.py
+++ b/database/tests/test_basic.py
@@ -131,6 +131,31 @@ class TestDatabaseBasic(TestDatabaseBase):
         res = plugin.readLog(id, time=0)
         self.assertEqual(0, len(res))
 
+    def test_markLogInvalid_preserves_value(self):
+        plugin = self.plugin()
+        id = self.create_item(plugin, 'main.num')
+        plugin.insertLog(id, time=0, duration=3600, val=10, it='num')
+
+        plugin.markLogInvalid(id, time=0)
+
+        res = plugin.readLog(id, time=0)
+        self.assertEqual(1, len(res))  # row still exists, unlike deleteLog
+        self.assertEqual(2, res[0][7])  # val_quality column, QUALITY_INVALID
+        self.assertEqual(10, res[0][4])  # val_num preserved
+        self.assertEqual(3600, res[0][2])  # duration preserved
+
+    def test_markLogValid_restores_previously_invalidated_row(self):
+        plugin = self.plugin()
+        id = self.create_item(plugin, 'main.num')
+        plugin.insertLog(id, time=0, duration=3600, val=10, it='num')
+        plugin.markLogInvalid(id, time=0)
+
+        plugin.markLogValid(id, time=0)
+
+        res = plugin.readLog(id, time=0)
+        self.assertEqual(0, res[0][7])  # val_quality column, QUALITY_VALID
+        self.assertEqual(10, res[0][4])  # val_num still intact
+
     def test_readLogs(self):
         plugin = self.plugin()
         id = self.create_item(plugin, 'main.num')

--- a/database/tests/test_single.py
+++ b/database/tests/test_single.py
@@ -1,5 +1,5 @@
 from plugins.database import Database
-from plugins.database.constants import QUALITY_NO_DATA
+from plugins.database.constants import QUALITY_INVALID, QUALITY_NO_DATA
 from plugins.database.tests.base import TestDatabaseBase
 
 
@@ -52,6 +52,27 @@ class TestDatabaseSingleQualityFilter(TestDatabaseBase):
 
         # Only the valid row (10, dur=3) should count.
         self.assertSingle(10, res)
+
+
+class TestDatabaseSingleInvalidQualityFilter(TestDatabaseBase):
+    """A manually invalidated row (val_quality=QUALITY_INVALID) must be
+    excluded from aggregations exactly like a QUALITY_NO_DATA gap - the
+    exclusion filter matches on val_quality alone, so this must hold even
+    though (unlike a gap) the row still carries a real, non-NULL value."""
+
+    def test_avg_excludes_invalidated_row_despite_preserved_value(self):
+        plugin = self.plugin()
+        id = self.create_item(plugin, 'main.num')
+        plugin.insertLog(id, time=self.t(0), duration=self.t(2), val=10, it='num')
+        # Value is preserved (unlike a QUALITY_NO_DATA gap), not None -
+        # only the quality flag marks it as excluded.
+        plugin.insertLog(id, time=self.t(2), duration=self.t(1), val=999, it='num', quality=QUALITY_INVALID)
+        plugin.insertLog(id, time=self.t(3), duration=self.t(2), val=20, it='num')
+
+        res = plugin._single('avg', start=self.t(0), end=self.t(6), item='main.num')
+
+        # Same math as the QUALITY_NO_DATA case: 15, not skewed by the 999.
+        self.assertSingle(15, res)
 
 
 class TestDatabaseSingle(TestDatabaseBase):

--- a/database/tests/test_store.py
+++ b/database/tests/test_store.py
@@ -11,7 +11,7 @@ import os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..'))
 
 from plugins.database.store import ItemStore, LogStore
-from plugins.database.constants import BufferEntry, QUALITY_VALID, QUALITY_NO_DATA
+from plugins.database.constants import BufferEntry, QUALITY_VALID, QUALITY_NO_DATA, QUALITY_INVALID
 from plugins.database.utils import to_timestamp
 
 
@@ -244,6 +244,43 @@ class TestLogStore(unittest.TestCase):
         self.log_store.insert(self.item_id, gap, 'num', changed=3600)
         rows = self.db.fetchall('SELECT val_quality FROM log WHERE item_id=? AND time=?', (self.item_id, 3000))
         self.assertEqual(rows[0][0], QUALITY_NO_DATA)
+
+    def test_set_quality_flips_quality_without_touching_value(self):
+        """set_quality() must be a reversible flag flip: duration/val_* stay put."""
+        e = self._entry(4000, 500, 42.0, QUALITY_VALID)
+        self.log_store.insert(self.item_id, e, 'num', changed=4500)
+
+        self.log_store.set_quality(self.item_id, QUALITY_INVALID, time=4000, changed=4500)
+
+        rows = self.db.fetchall(
+            'SELECT val_quality, val_num, duration FROM log WHERE item_id=? AND time=?', (self.item_id, 4000)
+        )
+        self.assertEqual(rows[0][0], QUALITY_INVALID)
+        self.assertAlmostEqual(rows[0][1], 42.0)  # val_num preserved
+        self.assertEqual(rows[0][2], 500)  # duration preserved
+
+    def test_set_quality_is_reversible(self):
+        e = self._entry(5000, 500, 7.5, QUALITY_VALID)
+        self.log_store.insert(self.item_id, e, 'num', changed=5500)
+
+        self.log_store.set_quality(self.item_id, QUALITY_INVALID, time=5000, changed=5500)
+        self.log_store.set_quality(self.item_id, QUALITY_VALID, time=5000, changed=5500)
+
+        rows = self.db.fetchall('SELECT val_quality, val_num FROM log WHERE item_id=? AND time=?', (self.item_id, 5000))
+        self.assertEqual(rows[0][0], QUALITY_VALID)
+        self.assertAlmostEqual(rows[0][1], 7.5)
+
+    def test_set_quality_only_matches_given_criteria(self):
+        """Same time+changed matching as delete_range - other rows untouched."""
+        for t in (100, 200, 300):
+            self.log_store.insert(self.item_id, self._entry(t, 50, float(t), QUALITY_VALID), 'num', changed=t)
+
+        self.log_store.set_quality(self.item_id, QUALITY_INVALID, time=200, changed=200)
+
+        rows = self.db.fetchall('SELECT time, val_quality FROM log WHERE item_id=? ORDER BY time', (self.item_id,))
+        self.assertEqual(
+            [(r[0], r[1]) for r in rows], [(100, QUALITY_VALID), (200, QUALITY_INVALID), (300, QUALITY_VALID)]
+        )
 
 
 if __name__ == '__main__':

--- a/database/tests/test_webif.py
+++ b/database/tests/test_webif.py
@@ -1,6 +1,8 @@
+import json
 import os
 from unittest import mock
 
+from plugins.database.constants import QUALITY_INVALID
 from plugins.database.tests.base import TestDatabaseBase
 from plugins.database.webif import WebInterface
 
@@ -51,3 +53,107 @@ class TestDatabaseWebifItemCsv(TestDatabaseBase):
         csv_path = fake_serve.call_args[0][0]
         self.addCleanup(lambda: os.path.exists(csv_path) and os.unlink(csv_path))
         self.assertTrue(os.path.isfile(csv_path))
+
+    def test_item_csv_includes_val_quality_column(self):
+        plugin = self.plugin()
+        webif = self._webif(plugin)
+        id = self.create_item(plugin, 'main.num')
+        plugin.insertLog(id, time=0, duration=3600, val=10, it='num')
+        plugin.markLogInvalid(id, time=0)
+
+        os.makedirs(os.path.join(self.sh.base_dir, 'var', 'db'), exist_ok=True)
+
+        with mock.patch('cherrypy.request'), mock.patch('cherrypy.lib.static.serve_download', return_value='served'):
+            webif.item_csv(str(id))
+
+        csv_path = os.path.join(self.sh.base_dir, 'var', 'db', f'{plugin.get_instance_name()}_item_{id}.csv')
+        self.addCleanup(lambda: os.path.exists(csv_path) and os.unlink(csv_path))
+        with open(csv_path, encoding='utf-8') as f:
+            lines = f.read().splitlines()
+        self.assertEqual('time,item_id,duration,val_str,val_num,val_bool,changed,val_quality', lines[0])
+        self.assertTrue(lines[1].endswith(str(QUALITY_INVALID)))
+
+
+class TestDatabaseWebifItemDetails(TestDatabaseBase):
+    def _webif(self, plugin):
+        # Same bypass as TestDatabaseWebifItemCsv - get_data_html() never
+        # touches the template environment either, only self.plugin.
+        webif = WebInterface.__new__(WebInterface)
+        webif.logger = plugin.logger
+        webif.webif_dir = ''
+        webif.plugin = plugin
+        webif.items = plugin.items
+        return webif
+
+    def test_get_data_html_item_details_includes_val_quality(self):
+        plugin = self.plugin()
+        webif = self._webif(plugin)
+        id = self.create_item(plugin, 'main.num')
+        now_ms = int(plugin.shtime.now().timestamp() * 1000)
+        plugin.insertLog(id, time=now_ms, duration=3600, val=10, it='num', changed=now_ms)
+        plugin.markLogInvalid(id, time=now_ms)
+
+        data = json.loads(webif.get_data_html(dataSet='item_details', params=str(id)))
+
+        self.assertEqual(1, len(data))
+        # dict keys become JSON strings on the wire - same as the existing
+        # numeric-index keys (e.g. '4' for val_num) this endpoint already emits.
+        self.assertEqual(QUALITY_INVALID, data[0]['7'])  # val_quality column
+        self.assertEqual(10, data[0]['4'])  # val_num still present alongside the flag
+
+
+class TestDatabaseWebifIndexDispatch(TestDatabaseBase):
+    def _webif(self, plugin):
+        # index() DOES reach the template environment once dispatch falls
+        # through to the item_details render - stub it out (unlike the
+        # item_csv/get_data_html bypass, which never touches it at all) so
+        # the dispatch logic itself can still be exercised for real.
+        webif = WebInterface.__new__(WebInterface)
+        webif.logger = plugin.logger
+        webif.webif_dir = ''
+        webif.plugin = plugin
+        webif.items = plugin.items
+        webif.tplenv = mock.MagicMock()
+        return webif
+
+    def test_invalidate_log_action_flags_row_and_renders_item_details(self):
+        plugin = self.plugin()
+        webif = self._webif(plugin)
+        id = self.create_item(plugin, 'main.num')
+        plugin.insertLog(id, time=0, duration=3600, val=10, it='num', changed=0)
+
+        webif.index(action='invalidate_log', item_id=id, item_path='main.num', time_orig=0, changed_orig=0)
+
+        res = plugin.readLog(id, time=0)
+        self.assertEqual(QUALITY_INVALID, res[0][7])
+        self.assertEqual(10, res[0][4])  # value preserved, not deleted
+        render_kwargs = webif.tplenv.get_template.return_value.render.call_args.kwargs
+        self.assertEqual('item_details', render_kwargs['action'])
+        self.assertTrue(render_kwargs['invalidate_triggered'])
+
+    def test_restore_log_action_clears_invalid_flag(self):
+        plugin = self.plugin()
+        webif = self._webif(plugin)
+        id = self.create_item(plugin, 'main.num')
+        plugin.insertLog(id, time=0, duration=3600, val=10, it='num', changed=0)
+        plugin.markLogInvalid(id, time=0)
+
+        webif.index(action='restore_log', item_id=id, item_path='main.num', time_orig=0, changed_orig=0)
+
+        res = plugin.readLog(id, time=0)
+        self.assertEqual(0, res[0][7])  # QUALITY_VALID
+        render_kwargs = webif.tplenv.get_template.return_value.render.call_args.kwargs
+        self.assertTrue(render_kwargs['restore_triggered'])
+
+    def test_delete_log_bulk_action_still_hard_deletes(self):
+        """The bulk 'clear entire history' action (no time_orig/changed_orig) must
+        remain a real delete - only the single-row path became reversible."""
+        plugin = self.plugin()
+        webif = self._webif(plugin)
+        id = self.create_item(plugin, 'main.num')
+        plugin.insertLog(id, time=0, duration=3600, val=10, it='num', changed=0)
+
+        webif.index(action='delete_log', item_id=id, item_path='main.num')
+
+        res = plugin.readLog(id, time=0)
+        self.assertEqual(0, len(res))

--- a/database/user_doc.rst
+++ b/database/user_doc.rst
@@ -460,6 +460,10 @@ Eintrag in der ``log``-Tabelle trägt jetzt eine Spalte ``val_quality``:
 | ``1`` | Keine Daten verfügbar (Lücke).  Alle ``val_*`` Spalten    |
 |       | sind ``NULL``.  Wird bei Aggregationen ausgeschlossen.    |
 +-------+-----------------------------------------------------------+
+| ``2`` | Manuell als ungültig markiert.  Der ursprüngliche Wert    |
+|       | bleibt erhalten, wird aber wie eine Lücke behandelt und   |
+|       | kann jederzeit wiederhergestellt werden.                  |
++-------+-----------------------------------------------------------+
 
 item.db_mark_invalid()
 -----------------------
@@ -513,6 +517,28 @@ Einträge mit ``val_quality = 1`` werden bei folgenden Funktionen automatisch
 
 Bei Rohwertabfragen (``raw``) erscheinen Lückeneinträge als ``NULL``, damit
 Visualisierungen die Unterbrechung als echte Lücke darstellen können.
+
+Einzelnen Datensatz ungültig markieren (Webinterface)
+--------------------------------------------------------
+
+In der Detailansicht eines Items (``log``-Tabelle) lässt sich ein einzelner
+Datensatz über das Papierkorb-Symbol als ungültig markieren, statt ihn zu
+löschen. Der Wert bleibt in der Datenbank erhalten, zählt aber ab sofort nicht
+mehr bei ``avg``, ``sum``, ``integrate``, ``on``, ``min`` und ``max`` mit.
+
+Ein hartes Löschen einzelner Datensätze würde die Dauer des vorherigen Eintrags
+verfälschen, da die Summe aller Dauern nicht mehr der tatsächlich vergangenen
+Zeit entspräche. Das Markieren als ungültig vermeidet das: Die Dauer des
+vorherigen Eintrags bleibt unangetastet, und der markierte Datensatz lässt
+sich über das Wiederherstellen-Symbol jederzeit zurücksetzen.
+
+Diese Aktion steht nur für die letzten beiden, noch offenen Werte eines Items
+nicht zur Verfügung (Schaltfläche ist deaktiviert), da diese den aktuell
+gültigen Wert des Items abbilden.
+
+Das vollständige Löschen der Werthistorie eines Items (Papierkorb-Symbol in der
+Übersicht) ist davon nicht betroffen und bleibt ein echtes, unwiderrufliches
+Löschen.
 
 Implizite Revalidierung
 ------------------------

--- a/database/webif/__init__.py
+++ b/database/webif/__init__.py
@@ -39,7 +39,10 @@ from ..constants import (
     COL_LOG_TIME,
     COL_LOG_VAL_BOOL,
     COL_LOG_VAL_NUM,
+    COL_LOG_VAL_QUALITY,
     COL_LOG_VAL_STR,
+    QUALITY_INVALID,
+    QUALITY_VALID,
 )
 
 # ------------------------------------------
@@ -94,13 +97,29 @@ class WebInterface(SmartPluginWebIf):
         if item_path is not None:
             item = self.plugin.items.return_item(item_path)
         delete_triggered = False
+        invalidate_triggered = False
+        restore_triggered = False
         if action is not None:
+            # Single-row deletion was replaced with a reversible invalidate/restore
+            # toggle (see markLogInvalid/markLogValid) - hard-deleting one entry
+            # corrupted duration-based aggregations for its neighbors. The bulk
+            # "clear entire item history" action (no time_orig/changed_orig) is
+            # unaffected and still a real delete.
+            if (
+                action == 'invalidate_log'
+                and item_id is not None
+                and time_orig is not None
+                and changed_orig is not None
+            ):
+                self.plugin.markLogInvalid(item_id, time=time_orig, changed=changed_orig)
+                action = 'item_details'
+                invalidate_triggered = True
+            if action == 'restore_log' and item_id is not None and time_orig is not None and changed_orig is not None:
+                self.plugin.markLogValid(item_id, time=time_orig, changed=changed_orig)
+                action = 'item_details'
+                restore_triggered = True
             if action == 'delete_log' and item_id is not None:
-                if time_orig is not None and changed_orig is not None:
-                    self.plugin.deleteLog(item_id, time=time_orig, changed=changed_orig)
-                    action = 'item_details'
-                else:
-                    self.plugin.deleteLog(item_id, time_end=time_end)
+                self.plugin.deleteLog(item_id, time_end=time_end)
                 delete_triggered = True
             if action == 'item_details' and item_id is not None:
                 if day is not None and month is not None and year is not None:
@@ -136,6 +155,7 @@ class WebInterface(SmartPluginWebIf):
                             COL_LOG_VAL_NUM,
                             COL_LOG_VAL_BOOL,
                             COL_LOG_CHANGED,
+                            COL_LOG_VAL_QUALITY,
                         ]:
                             if key not in [COL_LOG_TIME, COL_LOG_CHANGED]:
                                 value_dict[key] = row[key]
@@ -163,6 +183,9 @@ class WebInterface(SmartPluginWebIf):
                     month=month,
                     year=year,
                     delete_triggered=delete_triggered,
+                    invalidate_triggered=invalidate_triggered,
+                    restore_triggered=restore_triggered,
+                    quality_invalid=QUALITY_INVALID,
                 )
 
         tmpl = self.tplenv.get_template('index.html')
@@ -246,6 +269,7 @@ class WebInterface(SmartPluginWebIf):
                         COL_LOG_VAL_NUM,
                         COL_LOG_VAL_BOOL,
                         COL_LOG_CHANGED,
+                        COL_LOG_VAL_QUALITY,
                     ]:
                         if key not in [COL_LOG_TIME, COL_LOG_CHANGED]:
                             value_dict[key] = row[key]
@@ -296,6 +320,7 @@ class WebInterface(SmartPluginWebIf):
                         COL_LOG_VAL_NUM,
                         COL_LOG_VAL_BOOL,
                         COL_LOG_CHANGED,
+                        COL_LOG_VAL_QUALITY,
                     ]:
                         value_dict[key] = row[key]
                     log_array.append(value_dict)
@@ -304,9 +329,11 @@ class WebInterface(SmartPluginWebIf):
 
             with open(csv_file_path, 'w', encoding='utf-8') as f:
                 writer = csv.writer(f, dialect='excel')
-                writer.writerow(['time', 'item_id', 'duration', 'val_str', 'val_num', 'val_bool', 'changed'])
+                writer.writerow(
+                    ['time', 'item_id', 'duration', 'val_str', 'val_num', 'val_bool', 'changed', 'val_quality']
+                )
                 for data in reversed_arr:
-                    writer.writerow([data[0], data[1], data[2], data[3], data[4], data[5], data[6]])
+                    writer.writerow([data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7]])
 
             cherrypy.request.fileName = csv_file_path
             cherrypy.request.hooks.attach('on_end_request', self.download_complete)

--- a/database/webif/templates/item_details.html
+++ b/database/webif/templates/item_details.html
@@ -54,6 +54,24 @@ checkDate();
 		</button>
 	</div>
 {% endif %}
+{% if invalidate_triggered %}
+	<div class="mb-2 alert alert-success alert-dismissible fade show" role="alert">
+		<strong>{{ _('Der Wert wurde als ungültig markiert.') }}</strong><br/>
+		{{ _('Er ist ab sofort von Mittelwert-/Summen-/Integral-Berechnungen ausgeschlossen und kann jederzeit wiederhergestellt werden.') }}
+		<button type="button" class="close" data-dismiss="alert" aria-label="Close">
+			<span aria-hidden="true">&times;</span>
+		</button>
+	</div>
+{% endif %}
+{% if restore_triggered %}
+	<div class="mb-2 alert alert-success alert-dismissible fade show" role="alert">
+		<strong>{{ _('Der Wert wurde wiederhergestellt.') }}</strong><br/>
+		{{ _('Er wird wieder in Mittelwert-/Summen-/Integral-Berechnungen berücksichtigt.') }}
+		<button type="button" class="close" data-dismiss="alert" aria-label="Close">
+			<span aria-hidden="true">&times;</span>
+		</button>
+	</div>
+{% endif %}
 <div class="mb-2">
 	{{ _('Die folgenden Einträge entstammen der log Tabelle mit historischen Daten für das Item') }}
 	<strong id="item_path">{{ item_path }}</strong> {{ _('am') }} <strong>
@@ -91,15 +109,16 @@ checkDate();
 		</thead>
 		<tbody>
 			{% for data in log_array %}
-			  <tr id="{{ data[0] }}_{{ data[2] }}">
+			  {% set is_invalid = data[7] == quality_invalid %}
+			  <tr id="{{ data[0] }}_{{ data[2] }}" class="{% if is_invalid %}text-muted{% endif %}">
 					<td></td>
 			    <td id="{{ data[0] }}_{{ data[2] }}_id">{{ data[1] }}</td>
 			    <td id="{{ data[0] }}_{{ data[2] }}_time">{% if language == 'en' %}{{ data[0].strftime('%m/%d/%Y %H:%M:%S') }}{% else %}{{ data[0].strftime('%d.%m.%Y %H:%M:%S') }}{% endif %}</td>
 			    <td id="{{ data[0] }}_{{ data[2] }}_duration">{% if p._seconds(data[2]) == none %}{{ p._seconds(data[2]) }}{% else %}{{ ("%.2f"|format(p._seconds(data[2])|float)).rstrip('0').rstrip('.') }}{% endif %}</td>
-			    {% if item.property.type == 'num' %}<td class="py-1" id="{{ data[0] }}_{{ data[2] }}_value">{{ ("%.2f"|format(data[4]|float)).rstrip('0').rstrip('.') }}</td>{% endif %}
-			    {% if item.property.type == 'bool' %}<td class="py-1" id="{{ data[0] }}_{{ data[2] }}_value">{{ data[5] }}</td>{% endif %}
-			    {% if item.property.type == 'str' %}<td class="py-1" id="{{ data[0] }}_{{ data[2] }}_value">{{ data[3] }}</td>{% endif %}
-			    {% if item.property.type == 'foo' %}<td class="py-1" id="{{ data[0] }}_{{ data[2] }}_value">{{ data[3] }}</td>{% endif %}
+			    {% if item.property.type == 'num' %}<td class="py-1{% if is_invalid %} text-decoration-line-through{% endif %}" id="{{ data[0] }}_{{ data[2] }}_value">{{ ("%.2f"|format(data[4]|float)).rstrip('0').rstrip('.') }}</td>{% endif %}
+			    {% if item.property.type == 'bool' %}<td class="py-1{% if is_invalid %} text-decoration-line-through{% endif %}" id="{{ data[0] }}_{{ data[2] }}_value">{{ data[5] }}</td>{% endif %}
+			    {% if item.property.type == 'str' %}<td class="py-1{% if is_invalid %} text-decoration-line-through{% endif %}" id="{{ data[0] }}_{{ data[2] }}_value">{{ data[3] }}</td>{% endif %}
+			    {% if item.property.type == 'foo' %}<td class="py-1{% if is_invalid %} text-decoration-line-through{% endif %}" id="{{ data[0] }}_{{ data[2] }}_value">{{ data[3] }}</td>{% endif %}
 			    <td id="{{ data[0] }}_{{ data[2] }}_changed">{% if language == 'en' %}{{ data[6].strftime('%m/%d/%Y %H:%M:%S') }}{% else %}{{ data[6].strftime('%d.%m.%Y %H:%M:%S') }}{% endif %}</td>
 			    <td id="{{ data[0] }}_{{ data[2] }}_buttons">
 			    {% if loop.index < 3 and (day is none or (day+" "+month+" "+year == now.strftime('%d %m %Y'))) %}
@@ -107,10 +126,17 @@ checkDate();
 			    {% else %}
 			      {% set is_disabled = false %}
 			    {% endif %}
+			    {% if is_invalid %}
+			    <button {% if is_disabled %}disabled{% endif %} type="button"
+			    class="btn btn-{% if is_disabled %}secondary{% else %}warning{% endif %} btn-sm"
+			    title="{% if is_disabled %}{{ _('Wiederherstellen für aktuellen Wert nicht verfügbar.') }}{% else %}{{ _('Wert wiederherstellen') }}{% endif %}"
+			    onclick="window.location.href='?action=restore_log&item_id={{ data[1] }}&item_path={{ item_path }}&time_orig={{ data['0_orig'] }}&changed_orig={{ data['6_orig'] }}{% if day and month and year %}&day={{ day }}&month={{ month }}&year={{ year }}{% endif %}'"><i class="fas fa-trash-restore"></i></button></td>
+			    {% else %}
 			    <button {% if is_disabled %}disabled{% endif %} type="button"
 			    class="btn btn-{% if is_disabled %}secondary{% else %}danger{% endif %} btn-sm"
-			    title="{% if is_disabled %}{{ _('Wert löschen für aktuellen Wert nicht verfügbar.') }}{% else %}{{ _('Wert löschen') }}{% endif %}"
-			    onclick="confirmDelete('?action=delete_log&item_id={{ data[1] }}&item_path={{ item_path }}&time_orig={{ data['0_orig'] }}&changed_orig={{ data['6_orig'] }}{% if day and month and year %}&day={{ day }}&month={{ month }}&year={{ year }}{% endif %}','{{ _('Wollen Sie den Datensatz (Tabelle log) dieses Items wirklich löschen?') }}')"><i class="fas fa-trash-alt"></i></button></td>
+			    title="{% if is_disabled %}{{ _('Wert ungültig markieren für aktuellen Wert nicht verfügbar.') }}{% else %}{{ _('Wert ungültig markieren') }}{% endif %}"
+			    onclick="confirmDelete('?action=invalidate_log&item_id={{ data[1] }}&item_path={{ item_path }}&time_orig={{ data['0_orig'] }}&changed_orig={{ data['6_orig'] }}{% if day and month and year %}&day={{ day }}&month={{ month }}&year={{ year }}{% endif %}','{{ _('Wollen Sie diesen Datensatz als ungültig markieren? Er wird dadurch von Berechnungen ausgeschlossen, kann aber jederzeit wiederhergestellt werden.') }}')"><i class="fas fa-trash-alt"></i></button></td>
+			    {% endif %}
 			  </tr>
 			{% endfor %}
 		</tbody>
@@ -163,6 +189,7 @@ checkDate();
 						is_disabled = true;
 					else
 						is_disabled = false;
+					let is_invalid = objResponse[item][7] == {{ quality_invalid }};
 
 					{% if language == 'en' %}
 						date_time = month+"/"+day+"/"+year+" "+time;
@@ -183,6 +210,7 @@ checkDate();
 					{% if item.property.type == 'bool' %} value = objResponse[item][5];{% endif %}
 					{% if item.property.type == 'str' %} value = objResponse[item][3];{% endif %}
 					{% if item.property.type == 'foo' %} value = objResponse[item][3];{% endif %}
+					if (is_invalid) value = "<span class='text-decoration-line-through'>" + value + "</span>";
 					let changed = new Date(Date.parse(objResponse[item][6]));
 					let changed_day = String(changed.getDate()).padStart(2, '0');
 					let changed_month = String((changed.getMonth()+1)).padStart(2, '0');
@@ -194,14 +222,21 @@ checkDate();
 					let buttons = "";
 					let day_month_year = "";
 					if (day && month && year) day_month_year = "&day=" + day + "&month=" + month + "&year=" + year;
-					if (is_disabled)
+					if (is_invalid)
 					{
-					  buttons = "<button disabled type='button' class='btn btn-secondary btn-sm' title='{{ _('Wert löschen für aktuellen Wert nicht verfügbar.') }}'><i class='fas fa-trash-alt'></i></button>";
+						if (is_disabled)
+							buttons = "<button disabled type='button' class='btn btn-secondary btn-sm' title='{{ _('Wiederherstellen für aktuellen Wert nicht verfügbar.') }}'><i class='fas fa-trash-restore'></i></button>";
+						else
+							buttons = "<button type='button' class='btn btn-warning btn-sm' title='{{ _('Wert wiederherstellen') }}' onclick=\"window.location.href='?action=restore_log&item_id=" + item_id + "&item_path=" + item_path + "&time_orig=" + objResponse[item]['0_orig'] + "&changed_orig=" + objResponse[item]['6_orig'] + day_month_year + "'\"><i class='fas fa-trash-restore'></i></button>";
+					}
+					else if (is_disabled)
+					{
+					  buttons = "<button disabled type='button' class='btn btn-secondary btn-sm' title='{{ _('Wert ungültig markieren für aktuellen Wert nicht verfügbar.') }}'><i class='fas fa-trash-alt'></i></button>";
 					}
 
 					else
 					{
-						buttons = "<button type='button' class='btn btn-danger btn-sm' title='{{ _('Wert löschen') }}' onclick=\"confirmDelete('?action=delete_log&item_id=" + item_id + "&item_path=" + item_path + "&time_orig=" + objResponse[item]['0_orig'] + "&changed_orig=" + objResponse[item]['6_orig'] + day_month_year + "','{{ _('Wollen Sie den Datensatz (Tabelle log) dieses Items wirklich löschen?') }}')\"><i class='fas fa-trash-alt'></i></button>";
+						buttons = "<button type='button' class='btn btn-danger btn-sm' title='{{ _('Wert ungültig markieren') }}' onclick=\"confirmDelete('?action=invalidate_log&item_id=" + item_id + "&item_path=" + item_path + "&time_orig=" + objResponse[item]['0_orig'] + "&changed_orig=" + objResponse[item]['6_orig'] + day_month_year + "','{{ _('Wollen Sie diesen Datensatz als ungültig markieren? Er wird dadurch von Berechnungen ausgeschlossen, kann aber jederzeit wiederhergestellt werden.') }}')\"><i class='fas fa-trash-alt'></i></button>";
 					}
 					{% if language == 'en' %}
 						changed_date_time = changed_month+"/"+changed_day+"/"+changed_year+" "+changed_time;
@@ -211,6 +246,7 @@ checkDate();
 					let entry_id = objResponse[item][0].replace("T", " ");
 					let newRow = item_details_table.row.add( [ null, item_id, date_time, duration, value, changed_date_time, buttons ] ).draw(false).node();
 					newRow.id = entry_id+"_"+orig_duration;
+					if (is_invalid) $(newRow).addClass('text-muted');
 					$('td:eq(1)', newRow).attr('id', entry_id+'_'+orig_duration+'_id');
 					$('td:eq(2)', newRow).attr('id', entry_id+'_'+orig_duration+'_time');
 					$('td:eq(3)', newRow).attr('id', entry_id+'_'+orig_duration+'_duration').addClass('duration');


### PR DESCRIPTION
Instead of deleting invalid/wrong values from database history, mark them as "manually set to invalid" and removing them from all value calculations (avg, min, max, integrate). This keeps timespan-history correct and still removes the value from actual valid history.

Fixes #714 